### PR TITLE
Prod Release [25.01-3]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ EXPOSE 5757
 CMD mv /*.db build/dbs/ \
       &&  chown -R node:node build/dbs \
       || echo "No databases to move."; \
-    su node -c 'cd /morcus && PORT=5757 node build/server.js'
+    su node -c 'cd /morcus && PORT=5757 NODE_ENV=production node build/server.js'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Common arguments for this script (run `./morcus.sh --help` for full options):
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--build_ls`       | This processes Lewis and Short for use by the server. This needs to be run the first time and whenever you modify the Lewis and Short raw XML file. This is slow.                              |
 | `--build_sh`       | This processes Smith and Hall for use by the server. This needs to be run the first time and whenever you modify the Smith and Hall raw text file or any of the processing code. This is slow. |
-| `--prod`           | Builds the client and runs the server in production mode. This is slower.                                                                                                                      |
+| `--minify`         | Builds a minified client. This is used in production builds. This skips `React`'s `StrictMode` warnings as well.                                                                               |
 | `--transpile_only` | Skips `typescript` type checking. This is _faster_.                                                                                                                                            |
 
 ### Python Code (ML)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Source code for [morcus.net](https://www.morcus.net), a collection of digital to
 morcus.net development is currently done only on Linux machines.
 Before you get started, install `git` and:
 
-- If you want to work on the Typescript code: `npm`, `node` (other Node versions will likely work, but only version `20` is run in CI and guaranteed to work)
+- If you want to work on the Typescript code: `npm`, `node` (other Node versions will likely work, but only version `22` is run in CI and guaranteed to work)
 - If you want to work on the Python code: `python3.12` (other Python versions may work, but only `3.12` is run in CI and guaranteed to work.)
 
 ### Typescript Code (Client, Server, Workers)

--- a/first_time_setup.sh
+++ b/first_time_setup.sh
@@ -48,4 +48,4 @@ echo "LIB_XML_ROOT=$PWD/canonical-latinlit" >> $dot_env
 
 echo "Processing raw dictionary files, building the client, and starting the server."
 cd morcus-net || exit
-./morcus.sh web -b_ls -b_sh -b_li -b_ll --prod
+./morcus.sh web -b_ls -b_sh -b_li -b_ll -m

--- a/morcus.sh
+++ b/morcus.sh
@@ -1,11 +1,31 @@
 #!/bin/bash
 
-if echo "$*" | grep -e "--bun" -q
-then
+has_param() {
+    local term="$1"
+    shift
+    for arg; do
+        if [[ $arg == "$term" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+COMMAND="npm run ts-node --transpile_only"
+BUN_FLAG="0"
+ARGS="$@"
+
+if has_param '--node' "$@"; then
+  # If node is explicitly specified, don't try anything else.
+  true
+elif has_param '--bun' "$@"; then
   COMMAND="bun"
   BUN_FLAG="1"
-else
-  COMMAND="npm run ts-node --transpile_only"
-  BUN_FLAG="0"
+elif command -v bun 2>&1 >/dev/null; then
+  echo -e "\033[0;31mNote: bun detected, so automatically using bun. Pass --node to override this.\033[0m"
+  COMMAND="bun"
+  BUN_FLAG="1"
+  ARGS="$@ --bun"
 fi
-export BUN=$BUN_FLAG && $COMMAND src/scripts/run_morcus.ts -- "$@"
+
+export BUN=$BUN_FLAG && $COMMAND src/scripts/run_morcus.ts -- $ARGS

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "py-coverage": "python -m coverage run -m unittest discover && coverage xml --omit **/test_*.py -o coverage/coverage.xml",
     "ts-coverage": "npx jest --coverage --maxWorkers=8 --testPathIgnorePatterns src/integration/* --coveragePathIgnorePatterns src/integration",
     "coverage": "npm run ts-coverage && npm run py-coverage",
-    "ts-node": "node --max-old-space-size=4096 --env-file=.env -- node_modules/.bin/ts-node -P tsconfig.json -r tsconfig-paths/register",
+    "ts-node": "NODE_ENV=production node --max-old-space-size=4096 --env-file=.env -- node_modules/.bin/ts-node -P tsconfig.json -r tsconfig-paths/register",
     "tsnp": "NODE_ENV=production node --max-old-space-size=4096 --env-file=.env -- node_modules/.bin/ts-node -P tsconfig.json -r tsconfig-paths/register --transpile-only",
     "pytype": "python -m pytype src/py src/scripts",
     "server-p": "npm run ts-node src/web/nlp/processing_server.ts",

--- a/src/common/library/library_constants.ts
+++ b/src/common/library/library_constants.ts
@@ -13,6 +13,8 @@ const DE_RERUM_NATURA = "data/phi0550/phi001/phi0550.phi001.perseus-lat1.xml";
 const NEPOS_MILTIADES = "data/phi0588/abo001/phi0588.abo001.perseus-lat2.xml";
 const NEPOS_THEMISTOCLES =
   "data/phi0588/abo002/phi0588.abo002.perseus-lat2.xml";
+const AMMIANUS_MARCELLINUS =
+  "data/stoa0023/stoa001/stoa0023.stoa001.perseus-lat2.xml";
 
 // Two supported works are checked in to the repo itself for the sake of unit testing.
 export const LOCAL_REPO_WORKS = [CAESAR_DBG, PHAEDRUS_FABULAE];
@@ -35,4 +37,5 @@ export const ALL_SUPPORTED_WORKS = LOCAL_REPO_WORKS.concat([
   DE_RERUM_NATURA,
   NEPOS_MILTIADES,
   NEPOS_THEMISTOCLES,
+  AMMIANUS_MARCELLINUS,
 ]);

--- a/src/common/library/library_constants.ts
+++ b/src/common/library/library_constants.ts
@@ -31,7 +31,6 @@ export const ALL_SUPPORTED_WORKS = LOCAL_REPO_WORKS.concat([
   SALLUST_CATALINA1,
   DE_AMICITIA,
   CAESAR_BELLUM_CIVILIS,
-  // We're not handling the `lg` (line groups)!
   CATULLUS,
   DE_RERUM_NATURA,
   NEPOS_MILTIADES,

--- a/src/common/library/library_constants.ts
+++ b/src/common/library/library_constants.ts
@@ -1,41 +1,40 @@
-const CAESAR_DBG = "data/phi0448/phi001/phi0448.phi001.perseus-lat2.xml";
-const CAESAR_BELLUM_CIVILIS =
-  "data/phi0448/phi002/phi0448.phi002.perseus-lat2.xml";
-const PHAEDRUS_FABULAE = "data/phi0975/phi001/phi0975.phi001.perseus-lat2.xml";
-const CATULLUS = "data/phi0472/phi001/phi0472.phi001.perseus-lat2.xml";
+import { assert } from "@/common/assert";
 
-const OVID_AMORES = "data/phi0959/phi001/phi0959.phi001.perseus-lat2.xml";
-const TACITUS_GERMANIA = "data/phi1351/phi002/phi1351.phi002.perseus-lat1.xml";
-const JUVENAL_SATURAE = "data/phi1276/phi001/phi1276.phi001.perseus-lat2.xml";
-const SALLUST_CATALINA1 = "data/phi0631/phi001/phi0631.phi001.perseus-lat4.xml";
-const DE_AMICITIA = "data/phi0474/phi052/phi0474.phi052.perseus-lat2.xml";
-const DE_RERUM_NATURA = "data/phi0550/phi001/phi0550.phi001.perseus-lat1.xml";
-const NEPOS_MILTIADES = "data/phi0588/abo001/phi0588.abo001.perseus-lat2.xml";
-const NEPOS_THEMISTOCLES =
-  "data/phi0588/abo002/phi0588.abo002.perseus-lat2.xml";
-const AMMIANUS_MARCELLINUS =
-  "data/stoa0023/stoa001/stoa0023.stoa001.perseus-lat2.xml";
+export const LatinWorks = {
+  CAESAR_DBG: "phi0448.phi001.perseus-lat2",
+  CAESAR_BELLUM_CIVILIS: "phi0448.phi002.perseus-lat2",
+  PHAEDRUS_FABULAE: "phi0975.phi001.perseus-lat2",
+  CATULLUS: "phi0472.phi001.perseus-lat2",
+  OVID_AMORES: "phi0959.phi001.perseus-lat2",
+  TACITUS_GERMANIA: "phi1351.phi002.perseus-lat1",
+  JUVENAL_SATURAE: "phi1276.phi001.perseus-lat2",
+  SALLUST_CATALINA1: "phi0631.phi001.perseus-lat4",
+  DE_AMICITIA: "phi0474.phi052.perseus-lat2",
+  DE_RERUM_NATURA: "phi0550.phi001.perseus-lat1",
+  NEPOS_MILTIADES: "phi0588.abo001.perseus-lat2",
+  NEPOS_THEMISTOCLES: "phi0588.abo002.perseus-lat2",
+  AMMIANUS_MARCELLINUS: "stoa0023.stoa001.perseus-lat2",
+};
+
+export const EnglishTranslations: Record<string, string> = {
+  [LatinWorks.SALLUST_CATALINA1]: "phi0631.phi001.perseus-eng2",
+} satisfies { [K in keyof typeof LatinWorks]?: string };
+
+function toPerseusPath(workId: string): string {
+  const parts = workId.split(".");
+  assert(parts.length === 3, () => `Invalid work ID: ${workId}`);
+  return `data/${parts[0]}/${parts[1]}/${workId}.xml`;
+}
 
 // Two supported works are checked in to the repo itself for the sake of unit testing.
-export const LOCAL_REPO_WORKS = [CAESAR_DBG, PHAEDRUS_FABULAE];
+export const LOCAL_REPO_WORKS = [
+  toPerseusPath(LatinWorks.CAESAR_DBG),
+  toPerseusPath(LatinWorks.PHAEDRUS_FABULAE),
+];
 
-export const ALL_SUPPORTED_WORKS = LOCAL_REPO_WORKS.concat([
-  // Remove these next two for now, since it has strange optional
-  // nested elements that are not marked in the CTS header
-  // "data/phi0472/phi001/phi0472.phi001.perseus-lat2.xml",
-  // "data/phi0893/phi001/phi0893.phi001.perseus-lat2.xml",
+console.log(EnglishTranslations);
 
-  // Remove this for now, since it has whitespace between elements.
-  // "data/phi1318/phi001/phi1318.phi001.perseus-lat1.xml",
-  OVID_AMORES,
-  TACITUS_GERMANIA,
-  JUVENAL_SATURAE,
-  SALLUST_CATALINA1,
-  DE_AMICITIA,
-  CAESAR_BELLUM_CIVILIS,
-  CATULLUS,
-  DE_RERUM_NATURA,
-  NEPOS_MILTIADES,
-  NEPOS_THEMISTOCLES,
-  AMMIANUS_MARCELLINUS,
-]);
+export const ALL_SUPPORTED_WORKS = [
+  ...Object.values(LatinWorks).map(toPerseusPath),
+  ...Object.values(EnglishTranslations).map(toPerseusPath),
+];

--- a/src/common/library/library_constants.ts
+++ b/src/common/library/library_constants.ts
@@ -32,8 +32,6 @@ export const LOCAL_REPO_WORKS = [
   toPerseusPath(LatinWorks.PHAEDRUS_FABULAE),
 ];
 
-console.log(EnglishTranslations);
-
 export const ALL_SUPPORTED_WORKS = [
   ...Object.values(LatinWorks).map(toPerseusPath),
   ...Object.values(EnglishTranslations).map(toPerseusPath),

--- a/src/common/library/library_types.ts
+++ b/src/common/library/library_types.ts
@@ -16,7 +16,7 @@ export interface DocumentInfo {
   editor?: string;
   sponsor?: string;
   funder?: string;
-  workId?: string;
+  workId: string;
 }
 
 export namespace DocumentInfo {
@@ -26,7 +26,7 @@ export namespace DocumentInfo {
     editor: maybeUndefined(isString),
     sponsor: maybeUndefined(isString),
     funder: maybeUndefined(isString),
-    workId: maybeUndefined(isString),
+    workId: isString,
   });
 }
 

--- a/src/common/library/library_types.ts
+++ b/src/common/library/library_types.ts
@@ -61,6 +61,8 @@ export type ProcessedWorkContentNodeType =
   | "gap"
   | "b"
   | "space"
+  | "ul"
+  | "li"
   | "note";
 export interface ProcessedWork2 {
   /** Basic information about this work such as author or title. */

--- a/src/common/library/library_types.ts
+++ b/src/common/library/library_types.ts
@@ -3,6 +3,7 @@ import {
   Validator,
   instanceOf,
   isArray,
+  isBoolean,
   isNumber,
   isPair,
   isString,
@@ -102,6 +103,10 @@ export interface LibraryWorkMetadata {
   urlAuthor: string;
   /** The representation of the work name in a URL. */
   urlName: string;
+  /** The ID of the translation for this work. */
+  translationId?: string;
+  /** Whether this is a translation. */
+  isTranslation?: boolean;
 }
 
 export namespace LibraryWorkMetadata {
@@ -111,6 +116,8 @@ export namespace LibraryWorkMetadata {
     id: isString,
     urlAuthor: isString,
     urlName: isString,
+    translationId: maybeUndefined(isString),
+    isTranslation: maybeUndefined(isBoolean),
   });
 }
 

--- a/src/common/library/library_types.ts
+++ b/src/common/library/library_types.ts
@@ -18,6 +18,7 @@ export interface DocumentInfo {
   sponsor?: string;
   funder?: string;
   workId: string;
+  translationId?: string;
 }
 
 export namespace DocumentInfo {
@@ -28,6 +29,7 @@ export namespace DocumentInfo {
     sponsor: maybeUndefined(isString),
     funder: maybeUndefined(isString),
     workId: isString,
+    translationId: maybeUndefined(isString),
   });
 }
 

--- a/src/common/library/library_types.ts
+++ b/src/common/library/library_types.ts
@@ -59,6 +59,7 @@ export type ProcessedWorkContentNodeType =
   | "s"
   | "gap"
   | "b"
+  | "space"
   | "note";
 export interface ProcessedWork2 {
   /** Basic information about this work such as author or title. */

--- a/src/common/library/process_library.ts
+++ b/src/common/library/process_library.ts
@@ -74,7 +74,8 @@ function urlifyName(input: string): string {
 function processTeiCts2(
   root: XmlNode,
   workId: string,
-  patches?: LibraryPatch[]
+  patches?: LibraryPatch[],
+  translationId?: string
 ): ProcessedWork2 {
   const words = new Set<string>();
   const onWord = (word: string) => {
@@ -91,7 +92,7 @@ function processTeiCts2(
   const debugHelper = debugRoot === undefined ? undefined : { onWord };
   const result = processTei2(
     root,
-    { workId },
+    { workId, translationId },
     { patches, sideChannel: debugHelper }
   );
   const debugName = result.info.title.replaceAll(" ", "_");
@@ -114,7 +115,13 @@ export function processLibrary(
     const rawXml = parseRawXml(fs.readFileSync(workPath), {
       keepWhitespace: true,
     });
-    const result = processTeiCts2(rawXml, workId, patches.get(workId));
+    const translationId = EnglishTranslations[workId];
+    const result = processTeiCts2(
+      rawXml,
+      workId,
+      patches.get(workId),
+      translationId
+    );
     const rawTitle = result.info.title;
     const title = NAME_TO_DISPLAY_NAME.get(rawTitle) ?? rawTitle;
 
@@ -124,7 +131,7 @@ export function processLibrary(
       name: title,
       urlAuthor: urlifyAuthor(result.info.author),
       urlName: urlifyName(result.info.title),
-      translationId: EnglishTranslations[workId],
+      translationId,
       isTranslation: Object.values(EnglishTranslations).some(
         (translation) => translation === workId
       ),

--- a/src/common/library/process_library.ts
+++ b/src/common/library/process_library.ts
@@ -1,5 +1,8 @@
 import { envVar } from "@/common/env_vars";
-import { LOCAL_REPO_WORKS } from "@/common/library/library_constants";
+import {
+  EnglishTranslations,
+  LOCAL_REPO_WORKS,
+} from "@/common/library/library_constants";
 import {
   LIBRARY_INDEX,
   LIB_DEFAULT_DIR,
@@ -114,12 +117,17 @@ export function processLibrary(
     const result = processTeiCts2(rawXml, workId, patches.get(workId));
     const rawTitle = result.info.title;
     const title = NAME_TO_DISPLAY_NAME.get(rawTitle) ?? rawTitle;
+
     const metadata: LibraryWorkMetadata = {
       id: workId,
       author: result.info.author,
       name: title,
       urlAuthor: urlifyAuthor(result.info.author),
       urlName: urlifyName(result.info.title),
+      translationId: EnglishTranslations[workId],
+      isTranslation: Object.values(EnglishTranslations).some(
+        (translation) => translation === workId
+      ),
     };
     const encoded = stringifyMessage(result, [XmlNodeSerialization.DEFAULT]);
     const outputPath = `${outputDir}/${workId}`;

--- a/src/common/library/process_library.ts
+++ b/src/common/library/process_library.ts
@@ -36,6 +36,8 @@ const AUTHOR_TO_URL_LOOKUP = new Map<string, string>([
   ["Julius Caesar", "caesar"],
   ["P. Ovidius Naso", "ovid"],
   ["Cornelius Tacitus", "tacitus"],
+  ["C. Valerius Catullus", "catullus"],
+  ["M. Tullius Cicero", "cicero"],
 ]);
 
 const NAME_TO_DISPLAY_NAME = new Map<string, string>([

--- a/src/common/library/process_work.test.ts
+++ b/src/common/library/process_work.test.ts
@@ -147,7 +147,7 @@ describe("processTei2", () => {
     });
     const root = work.rows[0][1];
     expect(root.children[0]).toBe("Gallia ");
-    expect(root.children[2]).toBe("est");
+    expect(root.children[2]).toBe(" est");
     const note1 = XmlNode.assertIsNode(root.children[1]);
     expect(note1.getAttr("noteId")).toBe("0");
     expect(note1.children).toHaveLength(0);

--- a/src/common/library/process_work.test.ts
+++ b/src/common/library/process_work.test.ts
@@ -399,11 +399,9 @@ describe("processTei2", () => {
     const noteRoot = XmlNode.assertIsNode(checkPresent(work.notes?.[0]));
     expect(noteRoot.children).toHaveLength(2);
     expect(noteRoot.children[0]).toBe("text ");
-    expect(XmlNode.assertIsNode(noteRoot.children[1]).children).toEqual([
-      "“",
-      "more text",
-      "”",
-    ]);
+    const moreText = XmlNode.assertIsNode(noteRoot.children[1]);
+    expect(moreText.getAttr("rend")).toBe("italic");
+    expect(moreText.children).toEqual(["more text"]);
   });
 
   it("handles note markup for add", () => {

--- a/src/common/library/process_work.ts
+++ b/src/common/library/process_work.ts
@@ -682,12 +682,6 @@ export function processTei2(
   const { rows, notes } = processWorkBody(body[0], textParts, processOptions);
   const pages = divideWork(rows, textParts);
   const navTree = buildNavTree(pages);
-  return {
-    info: extractInfo(xmlRoot),
-    textParts,
-    rows,
-    pages,
-    navTree,
-    notes,
-  };
+  const info = { ...extractInfo(xmlRoot), workId: metadata.workId };
+  return { info, textParts, rows, pages, navTree, notes };
 }

--- a/src/common/library/process_work.ts
+++ b/src/common/library/process_work.ts
@@ -63,6 +63,12 @@ const KNOWN_NOTE_REND = new Set<string | undefined>([
   undefined,
   ...HANDLED_NOTE_REND,
 ]);
+const KNOWN_NOTE_ATTRS = new Set<string | undefined>([
+  "xml:lang",
+  "sid",
+  "uid",
+  "parent",
+]);
 
 type QuoteOpen = "‘" | "“" | "'" | '"';
 type QuoteClose = "’" | "”" | "'" | '"';
@@ -351,8 +357,7 @@ function preprocessTree(
       top.attrs.push(["leader", "1"]);
     }
     if (top.name === "note") {
-      // `sid`, `uid`, and `parent`.
-      assertEqual(top.attrs.length, 3);
+      top.attrs.forEach((attr) => assert(KNOWN_NOTE_ATTRS.has(attr[0])));
       const noteId = notes.length.toString();
       notes.push(top.deepcopy());
       top.attrs.push(["noteId", noteId]);

--- a/src/common/library/process_work.ts
+++ b/src/common/library/process_work.ts
@@ -827,7 +827,7 @@ function buildNavTree(pages: WorkPage[]): NavTreeNode {
 /** Returns the processed content of a TEI XML file. */
 export function processTei2(
   xmlRoot: XmlNode,
-  metadata: { workId: string },
+  metadata: { workId: string; translationId?: string },
   options?: ProcessTeiOptions
 ): ProcessedWork2 {
   const textParts = getTextparts(xmlRoot, metadata.workId);
@@ -843,6 +843,10 @@ export function processTei2(
   const { rows, notes } = processWorkBody(body[0], textParts, processOptions);
   const pages = divideWork(rows, textParts);
   const navTree = buildNavTree(pages);
-  const info = { ...extractInfo(xmlRoot), workId: metadata.workId };
+  const info = {
+    ...extractInfo(xmlRoot),
+    workId: metadata.workId,
+    translationId: metadata.translationId,
+  };
   return { info, textParts, rows, pages, navTree, notes };
 }

--- a/src/common/library/process_work.ts
+++ b/src/common/library/process_work.ts
@@ -87,17 +87,19 @@ const QUOTE_PAIRS: QuotePair[] = [
   ["'", "'"],
   ['"', '"'],
 ];
-const QUOTE_OPENS = new Set<QuoteOpen>(QUOTE_PAIRS.map((x) => x[1]));
-const QUOTE_CLOSES = new Set<QuoteClose>(QUOTE_PAIRS.map((x) => x[0]));
+const QUOTE_OPENS: Set<unknown> = new Set<QuoteOpen>(
+  QUOTE_PAIRS.map((x) => x[1])
+);
+const QUOTE_CLOSES: Set<unknown> = new Set<QuoteClose>(
+  QUOTE_PAIRS.map((x) => x[0])
+);
 const QUOTE_OPEN_FOR_CLOSE = new Map<QuoteClose, QuoteOpen>(QUOTE_PAIRS);
 
 function isQuoteOpen(x: unknown): x is QuoteOpen {
-  // @ts-expect-error
   return QUOTE_OPENS.has(x);
 }
 
 function isQuoteClose(x: unknown): x is QuoteClose {
-  // @ts-expect-error
   return QUOTE_CLOSES.has(x);
 }
 

--- a/src/common/library/process_work.ts
+++ b/src/common/library/process_work.ts
@@ -49,8 +49,14 @@ const NOTE_NODES = new Set([
   "emph",
   "foreign",
   "q",
+  "quote",
   "title",
   "gap",
+  "placeName",
+  "date",
+  "bibl",
+  "cit",
+  "pb",
   // TODO: Check how Scaife renders this.
   "add",
 ]);
@@ -65,6 +71,8 @@ const KNOWN_NOTE_REND = new Set<string | undefined>([
 ]);
 const KNOWN_NOTE_ATTRS = new Set<string | undefined>([
   "xml:lang",
+  "anchored",
+  "place",
   "sid",
   "uid",
   "parent",
@@ -497,7 +505,8 @@ function convertToRows(
 }
 
 function transformNoteNode(node: XmlNode): XmlNode {
-  assert(NOTE_NODES.has(node.name), node.toString());
+  // TODO: REMOVE node.toSting()!!!
+  assert(NOTE_NODES.has(node.name));
   if (node.name === "gap") {
     return new XmlNode("span", [], [" [gap] "]);
   }
@@ -510,12 +519,11 @@ function transformNoteNode(node: XmlNode): XmlNode {
   const baseChildren = node.children.map((c) =>
     typeof c === "string" ? c : transformNoteNode(c)
   );
-  const children =
-    node.name === "q"
-      ? ["“", ...baseChildren, "”"]
-      : node.name === "add"
-      ? ["<", ...baseChildren, ">"]
-      : baseChildren;
+  const children = QUOTE_NODES.has(node.name)
+    ? ["“", ...baseChildren, "”"]
+    : node.name === "add"
+    ? ["<", ...baseChildren, ">"]
+    : baseChildren;
   return new XmlNode("span", attrs, children);
 }
 
@@ -602,6 +610,11 @@ function transformContentNode(
     case "sic":
     case "said":
     case "emph":
+    // We may some day want to handle these, but for
+    // now just render the text.
+    // eslint-disable-next-line no-fallthrough
+    case "placeName":
+    case "date":
     case "num":
     case "orig":
     case "seg":

--- a/src/esbuild/morcus-net.esbuild.ts
+++ b/src/esbuild/morcus-net.esbuild.ts
@@ -30,7 +30,9 @@ const options: BuildOptions = {
   entryPoints: [SPA_ROOT, SERVICE_WORKER_ROOT],
   bundle: true,
   minify: envOptions.minify,
-  entryNames: "[dir]/[name].[hash]",
+  // We need the `client-bundle` suffix because that's the prefix we use
+  // to set the `immutable` cache control header in the server.
+  entryNames: "[dir]/[name].[hash].client-bundle",
   metafile: true,
   outdir: OUT_DIR,
   publicPath: "/",

--- a/src/esbuild/morcus-net.esbuild.ts
+++ b/src/esbuild/morcus-net.esbuild.ts
@@ -29,7 +29,7 @@ function getHash(): string {
 const options: BuildOptions = {
   entryPoints: [SPA_ROOT, SERVICE_WORKER_ROOT],
   bundle: true,
-  minify: envOptions.isProduction,
+  minify: envOptions.minify,
   entryNames: "[dir]/[name].[hash]",
   metafile: true,
   outdir: OUT_DIR,
@@ -37,7 +37,7 @@ const options: BuildOptions = {
   define: {
     COMMIT_HASH: `"${getHash()}"`,
     BUILD_DATE: `"${new Date().toString()}"`,
-    DEFAULT_EXPERIMENTAL_MODE: `${!envOptions.isProduction}`,
+    DEFAULT_EXPERIMENTAL_MODE: `${!envOptions.minify}`,
   },
   plugins: [
     printStatsPlugin(envOptions),

--- a/src/esbuild/plugins.ts
+++ b/src/esbuild/plugins.ts
@@ -146,13 +146,15 @@ function printBuildResult(
   if (metafile === undefined) {
     return;
   }
+  if (options?.analyzeBundle) {
+    console.log(esbuild.analyzeMetafileSync(metafile));
+  }
   for (const output in metafile.outputs) {
     const data = metafile.outputs[output];
     const size = (data.bytes / 1000).toFixed(2);
     console.log("entryPoint: " + data.entryPoint);
     console.log(`output: ${output} [${size} kB]\n`);
     if (options?.analyzeBundle) {
-      console.log(esbuild.analyzeMetafileSync(metafile));
       const metaPath = `${data.entryPoint}.esbuild.meta.json`;
       fs.writeFileSync(metaPath, JSON.stringify(metafile));
     }

--- a/src/esbuild/plugins.ts
+++ b/src/esbuild/plugins.ts
@@ -168,9 +168,11 @@ async function compressFile(
   compressor: (buf: Buffer) => Promise<Buffer>
 ) {
   const outFile = `${fileName}.${ext}`;
+  const start = performance.now();
   const compressed = await compressor(buffer);
+  const elapsed = (performance.now() - start).toFixed(2);
   const size = (compressed.byteLength / 1000).toFixed(2);
-  console.log(`${ext} compressed: ${outFile} [${size} kB]`);
+  console.log(`${ext} compressed: ${outFile} [${size} kB, ${elapsed} ms]`);
   return fs.promises.writeFile(outFile, compressed);
 }
 

--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -3,7 +3,7 @@
 import esbuild from "esbuild";
 
 export interface BundleOptions {
-  isProduction: boolean;
+  minify: boolean;
   watch: boolean;
   analyzeBundle: boolean;
   typeCheck: boolean;
@@ -13,7 +13,7 @@ export interface BundleOptions {
 export namespace BundleOptions {
   export function get(): BundleOptions {
     return {
-      isProduction: process.env.NODE_ENV === "production",
+      minify: process.env.MINIFY === "1",
       watch: process.env.WATCH === "1",
       analyzeBundle: process.env.ANALYZE_BUNDLE === "1",
       typeCheck: process.env.RUN_TSC === "1",

--- a/src/integration/suites/browser_e2e.test.ts
+++ b/src/integration/suites/browser_e2e.test.ts
@@ -38,11 +38,10 @@ test.describe("general navigation", () => {
   test("has working tab navigation", async ({ page, isMobile, viewport }) => {
     await page.goto("/");
     if (isMobile || checkPresent(viewport?.width) < 400) {
-      skipIfWebkit("The drawer animation doesn't seem to work on Webkit.");
       // Click into the hamburger menu
       await click(page.getByLabel("site pages"));
     }
-    await click(page.getByText("About").nth(0));
+    await click(page.locator('button:text("About")').nth(0));
 
     await expect(page.getByText("GPL-3.0")).toBeVisible();
     await expect(page.getByText("CC BY-SA 4.0")).toBeVisible();

--- a/src/integration/suites/browser_e2e.test.ts
+++ b/src/integration/suites/browser_e2e.test.ts
@@ -245,9 +245,15 @@ test.describe("main reader", () => {
     ).toBeVisible();
   });
 
-  test("has working scroll to line", async ({ page }) => {
+  test("has working scroll to line from UI from URL", async ({ page }) => {
     skipIfWebkit("viewport assertions don't yet work on Webkit.");
-    await page.goto("/work/juvenal/saturae?pg=2");
+    await page.goto("/work/juvenal/saturae?id=1.2&l=160");
+    await expect(page.getByText("Britannos")).toBeInViewport();
+  });
+
+  test("has working scroll to line from UI", async ({ page }) => {
+    skipIfWebkit("viewport assertions don't yet work on Webkit.");
+    await page.goto("/work/juvenal/saturae?id=1.2");
     await expect(page.getByText("Britannos")).toBeVisible();
     await expect(page.getByText("Britannos")).not.toBeInViewport();
 
@@ -256,7 +262,6 @@ test.describe("main reader", () => {
     await page.keyboard.type("161");
     await page.keyboard.press("Enter");
 
-    // Usually the scroll takes ~300 ms.
     await expect(page.getByText("Britannos")).toBeInViewport();
   });
 

--- a/src/integration/suites/browser_e2e.test.ts
+++ b/src/integration/suites/browser_e2e.test.ts
@@ -212,21 +212,27 @@ test.describe("main reader", () => {
     await expect(page.getByText("Aeduos").nth(0)).toBeVisible();
   });
 
-  test("handles legacy pg links in works", async ({ page }) => {
+  test("handles missing id in works", async ({ page }) => {
     await page.goto("/library");
-    await page.goto("/work/caesar/de_bello_gallico?pg=3");
-    await expect(page.getByText("Orgetorix")).toBeVisible();
 
+    await page.goto("/work/caesar/de_bello_gallico");
+    await expect(page.getByText("Gallia").nth(0)).toBeVisible();
     // Make sure we replaced the URL and then can go back.
-    await expect(page).toHaveURL(/\/work\/caesar\/de_bello_gallico\?id=1\.3$/);
+    await expect(page).toHaveURL(/\/work\/caesar\/de_bello_gallico\?id=1\.1$/);
+
     await page.goBack();
     await expect(page.getByText("Welcome to the library")).toBeVisible();
     await expect(page).toHaveURL(/\/library$/);
   });
 
   test("shows works by name and author and page", async ({ page }) => {
+    await page.goto("/library");
     await page.goto("/work/caesar/de_bello_gallico?id=1.3");
     await expect(page.getByText("Orgetorix")).toBeVisible();
+
+    await page.goBack();
+    await expect(page.getByText("Welcome to the library")).toBeVisible();
+    await expect(page).toHaveURL(/\/library$/);
   });
 
   test("handles clicky vocab", async ({ page }) => {

--- a/src/scripts/prod_build_steps.ts
+++ b/src/scripts/prod_build_steps.ts
@@ -87,7 +87,7 @@ const PROCESS_LAT_LIB: StepConfig = {
 };
 const MAKE_BUNDLE: StepConfig = {
   operation: () => {
-    const childEnv = { ...process.env, RUN_TSC: "1" };
+    const childEnv = { ...process.env, RUN_TSC: "1", MINIFY: "1" };
     return shellStep(
       "npm run tsnp src/esbuild/morcus-net.esbuild.ts",
       childEnv

--- a/src/scripts/prod_build_steps.ts
+++ b/src/scripts/prod_build_steps.ts
@@ -87,7 +87,12 @@ const PROCESS_LAT_LIB: StepConfig = {
 };
 const MAKE_BUNDLE: StepConfig = {
   operation: () => {
-    const childEnv = { ...process.env, RUN_TSC: "1", MINIFY: "1" };
+    const childEnv = {
+      ...process.env,
+      RUN_TSC: "1",
+      MINIFY: "1",
+      COMPRESS: "1",
+    };
     return shellStep(
       "npm run tsnp src/esbuild/morcus-net.esbuild.ts",
       childEnv

--- a/src/scripts/run_morcus.ts
+++ b/src/scripts/run_morcus.ts
@@ -183,6 +183,10 @@ function parseArguments() {
       help: "Runs supported commands with bun.",
       action: "store_true",
     });
+    subcommand.add_argument("--node", {
+      help: "Runs supported commands with node.",
+      action: "store_true",
+    });
   }
 
   return parser.parse_args();

--- a/src/scripts/run_morcus.ts
+++ b/src/scripts/run_morcus.ts
@@ -141,6 +141,10 @@ function parseArguments() {
     help: "Minifies the bundle after building.",
     action: "store_true",
   });
+  web.add_argument("-c", "--compress", {
+    help: "Stores pre-compressed bundle outputs.",
+    action: "store_true",
+  });
   web.add_argument("-to", "--transpile_only", {
     help: "Skips type checking for the client and server.",
     action: "store_true",

--- a/src/web/client/components/app_bar.test.tsx
+++ b/src/web/client/components/app_bar.test.tsx
@@ -32,6 +32,13 @@ beforeEach(() => {
   indexedDB = new IDBFactory();
 });
 
+beforeAll(() => {
+  // js-dom doesn't yet support `dialog`.
+  HTMLDialogElement.prototype.show = jest.fn();
+  HTMLDialogElement.prototype.showModal = jest.fn();
+  HTMLDialogElement.prototype.close = jest.fn();
+});
+
 describe("App Bar View", () => {
   const pages: ResponsiveAppBar.Page[] = [
     {

--- a/src/web/client/components/app_bar.tsx
+++ b/src/web/client/components/app_bar.tsx
@@ -54,28 +54,25 @@ function DrawerMenu(props: {
       contentProps={{
         className: "menu",
       }}>
-      <div
-        role="navigation"
-        onClick={props.onClose}
-        id="menu-appbar"
-        className="text md">
+      <div role="navigation" id="menu-appbar" className="drawerContents">
         {pages.map((page) => (
           <div key={page.name}>
-            <SpanButton
+            <button
               key={page.name}
               onClick={props.onPageClick(page.targetPath)}
               className={
-                props.isCurrentPage(page.targetPath)
+                "text md " +
+                (props.isCurrentPage(page.targetPath)
                   ? "menuItemActive"
-                  : "menuItemInactive"
+                  : "menuItemInactive")
               }
               style={{
                 padding: "16px 24px",
                 display: "block",
-                justifyContent: "center",
+                width: "100%",
               }}>
               <b>{page.name}</b>
-            </SpanButton>
+            </button>
             <Divider key={page.name + "_divider"} />
           </div>
         ))}

--- a/src/web/client/components/app_bar.tsx
+++ b/src/web/client/components/app_bar.tsx
@@ -2,11 +2,7 @@ import * as React from "react";
 
 import { GlobalSettingsContext } from "@/web/client/components/global_flags";
 import { Router } from "@/web/client/router/router_v2";
-import {
-  Container,
-  Divider,
-  SpanButton,
-} from "@/web/client/components/generic/basics";
+import { Container, Divider } from "@/web/client/components/generic/basics";
 import { IconButton, SvgIcon } from "@/web/client/components/generic/icons";
 import { useMediaQuery } from "@/web/client/utils/media_query";
 import { Drawer } from "@/web/client/components/generic/overlays";
@@ -61,17 +57,15 @@ function DrawerMenu(props: {
               key={page.name}
               onClick={props.onPageClick(page.targetPath)}
               className={
-                "text md " +
-                (props.isCurrentPage(page.targetPath)
-                  ? "menuItemActive"
-                  : "menuItemInactive")
+                "text md menuItem" +
+                (props.isCurrentPage(page.targetPath) ? " active" : "")
               }
               style={{
                 padding: "16px 24px",
                 display: "block",
                 width: "100%",
               }}>
-              <b>{page.name}</b>
+              {page.name}
             </button>
             <Divider key={page.name + "_divider"} />
           </div>
@@ -150,26 +144,23 @@ export function ResponsiveAppBar(props: ResponsiveAppBar.Props) {
             }}>
             <LogoImage />
           </div>
-          <div
-            style={{ flexGrow: 1, display: isSmall ? "none" : "flex" }}
-            className="text md">
+          <div style={{ flexGrow: 1, display: isSmall ? "none" : "flex" }}>
             {mainPages.map((page) => (
-              <SpanButton
+              <button
                 key={page.name}
                 onAuxClick={() => window.open(page.targetPath)}
                 onClick={handlePageClick(page.targetPath)}
                 className={
-                  isCurrentPage(page.targetPath)
-                    ? "menuItemActive"
-                    : "menuItemInactive"
+                  "text md menuItem" +
+                  (isCurrentPage(page.targetPath) ? " active" : "")
                 }
                 style={{
                   marginLeft: "8px",
                   marginRight: "8px",
                   display: "block",
                 }}>
-                <b>{page.name}</b>
-              </SpanButton>
+                {page.name}
+              </button>
             ))}
           </div>
           <div>

--- a/src/web/client/components/generic/overlays.tsx
+++ b/src/web/client/components/generic/overlays.tsx
@@ -44,6 +44,7 @@ export function BaseDialog(props: PropsWithChildren<BaseDialogProps>) {
     else dialogRef.current?.close();
   }, [open]);
 
+  if (!open) return null;
   return (
     <dialog
       ref={dialogRef}

--- a/src/web/client/components/global_flags.tsx
+++ b/src/web/client/components/global_flags.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { PropsWithChildren, createContext } from "react";
-import { defaultExperimentalMode } from "@/web/client/define_vars";
 
 const SETTINGS_STORAGE_KEY = "GlobalSettings";
 
@@ -50,7 +49,7 @@ export function getGlobalSettings(): GlobalSettings {
   return storageSetting !== null
     ? toGlobalSettings(JSON.parse(storageSetting))
     : {
-        experimentalMode: defaultExperimentalMode(),
+        experimentalMode: false,
         highlightStrength: DEFAULT_HIGHLIGHT_STRENGTH,
         darkMode: false,
         embeddedInflectedSearch: true,

--- a/src/web/client/components/global_flags.tsx
+++ b/src/web/client/components/global_flags.tsx
@@ -4,7 +4,7 @@ import { defaultExperimentalMode } from "@/web/client/define_vars";
 
 const SETTINGS_STORAGE_KEY = "GlobalSettings";
 
-export const DEFAULT_HIGHLIGHT_STRENGTH = 50;
+export const DEFAULT_HIGHLIGHT_STRENGTH = 40;
 
 export interface GlobalBooleans {
   experimentalMode?: boolean;
@@ -54,6 +54,7 @@ export function getGlobalSettings(): GlobalSettings {
         highlightStrength: DEFAULT_HIGHLIGHT_STRENGTH,
         darkMode: false,
         embeddedInflectedSearch: true,
+        inflectedSearch: true,
         fontFamily: "sans-serif",
       };
 }

--- a/src/web/client/components/report_issue_dialog.test.tsx
+++ b/src/web/client/components/report_issue_dialog.test.tsx
@@ -17,17 +17,26 @@ beforeEach(() => {
   mockCallApi.mockResolvedValue("");
 });
 
+const mockShowModal = jest.fn();
+const mockClose = jest.fn();
+beforeAll(() => {
+  // js-dom doesn't yet support `dialog`.
+  HTMLDialogElement.prototype.show = jest.fn();
+  HTMLDialogElement.prototype.showModal = mockShowModal;
+  HTMLDialogElement.prototype.close = mockClose;
+});
+
 describe("Report Issue Dialog", () => {
   it("is not shown when closed", async () => {
     const mockOnClose = jest.fn(() => {});
     render(<ReportIssueDialog show={false} onClose={mockOnClose} />);
-    expect(screen.queryByText("Issues / Feedback")).toBeNull();
+    expect(mockShowModal).not.toHaveBeenCalled();
   });
 
   it("is shown when open", async () => {
     const mockOnClose = jest.fn(() => {});
     render(<ReportIssueDialog show onClose={mockOnClose} />);
-    expect(screen.queryByText("Issues / Feedback")).not.toBeNull();
+    expect(mockShowModal).toHaveBeenCalled();
   });
 
   it("calls close on cancel", async () => {

--- a/src/web/client/components/single_page_app.test.tsx
+++ b/src/web/client/components/single_page_app.test.tsx
@@ -41,6 +41,13 @@ const OMNIS_PAGE: SinglePageApp.Page = {
   Content: () => <div>OmnisPage</div>,
 };
 
+beforeAll(() => {
+  // js-dom doesn't yet support `dialog`.
+  HTMLDialogElement.prototype.show = jest.fn();
+  HTMLDialogElement.prototype.showModal = jest.fn();
+  HTMLDialogElement.prototype.close = jest.fn();
+});
+
 describe("Single Page App View", () => {
   const pages: SinglePageApp.Page[] = [GALLIA_PAGE, OMNIS_PAGE];
   const experimentPages: SinglePageApp.Page[] = [

--- a/src/web/client/define_vars.test.ts
+++ b/src/web/client/define_vars.test.ts
@@ -1,9 +1,4 @@
-import {
-  defaultExperimentalMode,
-  getBuildDate,
-  getCommitHash,
-  tryOr,
-} from "@/web/client/define_vars";
+import { getBuildDate, getCommitHash, tryOr } from "@/web/client/define_vars";
 
 describe("define_vars", () => {
   test("tryOr returns expected", () => {
@@ -22,9 +17,5 @@ describe("define_vars", () => {
 
   it("falls back to undefined for build date", () => {
     expect(getBuildDate()).toBe("undefined");
-  });
-
-  it("falls back to false for experimental mode", () => {
-    expect(defaultExperimentalMode()).toBe(false);
   });
 });

--- a/src/web/client/define_vars.ts
+++ b/src/web/client/define_vars.ts
@@ -1,6 +1,5 @@
 declare const COMMIT_HASH: string;
 declare const BUILD_DATE: string;
-declare const DEFAULT_EXPERIMENTAL_MODE: boolean;
 
 export function tryOr<T>(f: () => T, fallback: T): T {
   try {
@@ -16,8 +15,4 @@ export function getCommitHash(): string {
 
 export function getBuildDate(): string {
   return tryOr(() => BUILD_DATE.trim(), "undefined");
-}
-
-export function defaultExperimentalMode(): boolean {
-  return tryOr(() => DEFAULT_EXPERIMENTAL_MODE, false);
 }

--- a/src/web/client/pages/dictionary/dictionary_utils.test.tsx
+++ b/src/web/client/pages/dictionary/dictionary_utils.test.tsx
@@ -67,18 +67,23 @@ describe("xmlNodeToJsx", () => {
     const root = new XmlNode(
       "span",
       [],
-      ["Caesar", new XmlNode("span", [], ["Gaius"])]
+      ["Caesar", new XmlNode("span", [], ["Pompey    Crassus"])]
     );
     const result = xmlNodeToJsx(root);
 
     expect(result.props.children).toHaveLength(2);
     expectMatchesJsx(
       result.props.children[0],
-      <LatLink word="Caesar" key={0} />
+      <LatLink word="Caesar" key="0.0" />
     );
     expectMatchesJsx(
       result.props.children[1].props.children[0],
-      <LatLink word="Gaius" key={0} />
+      <LatLink word="Pompey" key="0.6" />
+    );
+    expect(result.props.children[1].props.children[1]).toBe("    ");
+    expectMatchesJsx(
+      result.props.children[1].props.children[2],
+      <LatLink word="Crassus" key="0.10" />
     );
   });
 

--- a/src/web/client/pages/dictionary/dictionary_utils.tsx
+++ b/src/web/client/pages/dictionary/dictionary_utils.tsx
@@ -252,14 +252,16 @@ export function xmlNodeToJsx(
       return xmlNodeToJsx(
         child,
         highlightId,
-        child.getAttr("id") || `${idx}`,
+        child.getAttr("id") ?? `${idx}`,
         isEmbedded
       );
     }
     if (!shouldLinkifyWords) {
       return child;
     }
-    return processWords(child, (word, i) => <LatLink word={word} key={i} />);
+    return processWords(child, (word, i) => (
+      <LatLink word={word} key={`${idx}.${i}`} />
+    ));
   });
 
   if (titleText !== undefined) {

--- a/src/web/client/pages/dictionary/dictionary_v2.test.tsx
+++ b/src/web/client/pages/dictionary/dictionary_v2.test.tsx
@@ -28,6 +28,13 @@ jest.mock("@/web/client/utils/media_query", () => {
 import { useMediaQuery } from "@/web/client/utils/media_query";
 import { GlobalSettingsContext } from "@/web/client/components/global_flags";
 
+beforeAll(() => {
+  // js-dom doesn't yet support `dialog`.
+  HTMLDialogElement.prototype.show = jest.fn();
+  HTMLDialogElement.prototype.showModal = jest.fn();
+  HTMLDialogElement.prototype.close = jest.fn();
+});
+
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 console.debug = jest.fn();
 

--- a/src/web/client/pages/dictionary/dictionary_v2.tsx
+++ b/src/web/client/pages/dictionary/dictionary_v2.tsx
@@ -191,7 +191,7 @@ function getEntriesByDict(
     const rawEntries = response[dictKey];
     const entries = rawEntries.map((e, i) => ({
       element: xmlNodeToJsx(e.entry, hash, undefined, isEmbedded),
-      key: e.entry.getAttr("id") || `${dictKey}${i}`,
+      key: e.entry.getAttr("id") ?? `${dictKey}${i}`,
       inflections: e.inflections,
       subsections: e.subsections,
     }));

--- a/src/web/client/pages/dictionary/search/dictionary_search.test.tsx
+++ b/src/web/client/pages/dictionary/search/dictionary_search.test.tsx
@@ -24,6 +24,13 @@ afterEach(() => {
 
 const BOTH_DICTS = [LatinDict.LewisAndShort, LatinDict.SmithAndHall];
 
+beforeAll(() => {
+  // js-dom doesn't yet support `dialog`.
+  HTMLDialogElement.prototype.show = jest.fn();
+  HTMLDialogElement.prototype.showModal = jest.fn();
+  HTMLDialogElement.prototype.close = jest.fn();
+});
+
 describe("DictionarySearch", () => {
   beforeAll(() => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
@@ -143,8 +150,8 @@ describe("DictionarySearch", () => {
     await user.click(settings);
 
     expect(screen.queryByText("Dictionary Options")).not.toBeNull();
-    const lsCheck = screen.getAllByRole("checkbox");
-    await user.click(lsCheck[0]);
+    const lsCheck = screen.getByText("Lewis and Short");
+    await user.click(lsCheck);
     expect(mockSetDicts).toHaveBeenCalledWith([LatinDict.SmithAndHall]);
   });
 

--- a/src/web/client/pages/dictionary/search/dictionary_search.test.tsx
+++ b/src/web/client/pages/dictionary/search/dictionary_search.test.tsx
@@ -169,6 +169,6 @@ describe("DictionarySearch", () => {
     await user.click(increment!);
 
     const storage = JSON.parse(localStorage.getItem("GlobalSettings")!);
-    expect(storage.highlightStrength).toBe(70);
+    expect(storage.highlightStrength).toBe(60);
   });
 });

--- a/src/web/client/pages/dictionary/search/dictionary_search.tsx
+++ b/src/web/client/pages/dictionary/search/dictionary_search.tsx
@@ -160,12 +160,20 @@ function SearchSettingsDialog(props: {
   );
 }
 
+function LangChip(props: { lang: DictLang }) {
+  return (
+    <DictChip
+      label={props.lang}
+      className={props.lang === "La" ? "lsChip" : "shChip"}
+    />
+  );
+}
+
 function AutocompleteOption(props: { option: [DictLang, string] }) {
   const from = props.option[0];
-  const className = from === "En" ? "shChip" : "lsChip";
   return (
     <>
-      <DictChip label={from} className={className} />
+      <LangChip lang={from} />
       <span style={{ marginLeft: 10 }}>{props.option[1]}</span>
     </>
   );
@@ -248,6 +256,12 @@ function SettingsPreview(props: {
     : globalSettings.data.inflectedSearch;
   const inflectionMode =
     !shouldDisable.inflections && rawInflectionSetting === true;
+  const langs = new Set(
+    props.dicts
+      .filter((dict) => !shouldDisable[dict.key])
+      .map((d) => d.languages.from)
+      .filter((lang) => lang !== "*")
+  );
 
   return (
     <>
@@ -260,16 +274,14 @@ function SettingsPreview(props: {
           marginRight: "12px",
         }}>
         In{" "}
-        {props.dicts
-          .filter((dict) => !shouldDisable[dict.key] && dict.key !== "NUM")
-          .map((dict) => (
-            <span
-              key={dict.key}
-              style={{ marginRight: "2px", cursor: "pointer" }}
-              onClick={props.openDialog}>
-              <DictChip label={dict.key} />
-            </span>
-          ))}
+        {Array.from(langs).map((lang) => (
+          <span
+            key={lang}
+            style={{ marginRight: "2px", cursor: "pointer" }}
+            onClick={props.openDialog}>
+            <LangChip lang={lang} />
+          </span>
+        ))}
       </span>
       <span
         className="text light xxs compact"

--- a/src/web/client/pages/library/base_reader.test.tsx
+++ b/src/web/client/pages/library/base_reader.test.tsx
@@ -2,7 +2,10 @@
  * @jest-environment jsdom
  */
 
-import { handleSideTap } from "@/web/client/pages/library/base_reader";
+import {
+  handleSideTap,
+  makeOnDrag,
+} from "@/web/client/pages/library/base_reader";
 
 global.window.innerHeight = 5757;
 global.window.innerWidth = 420;
@@ -24,5 +27,90 @@ describe("handleSideTap", () => {
     const listener = jest.fn();
     handleSideTap({ clientX: 400 }, listener);
     expect(listener).toHaveBeenCalledWith("Left", 1);
+  });
+});
+
+describe("makeOnDrag", () => {
+  const MAX_SIZE = 500;
+
+  let dragStartLen: React.MutableRefObject<number | undefined>;
+  let dragStartPos: React.MutableRefObject<number | undefined>;
+  let currentLen: number = 5;
+  let setCurrentLen: jest.Mock;
+  let onDrag: (currentPos: number) => boolean;
+
+  function setupCallback(options?: {
+    minRatio?: number;
+    maxRatio?: number;
+    reverse?: boolean;
+  }) {
+    dragStartLen = { current: 50 };
+    dragStartPos = { current: 100 };
+    setCurrentLen = jest.fn((cb) => {
+      currentLen = cb(currentLen);
+    });
+    onDrag = makeOnDrag(
+      dragStartLen,
+      dragStartPos,
+      setCurrentLen,
+      () => MAX_SIZE,
+      options?.minRatio,
+      options?.maxRatio,
+      options?.reverse
+    );
+  }
+
+  beforeEach(() => {
+    setupCallback();
+  });
+
+  it("returns false if dragStartLen is undefined", () => {
+    dragStartLen.current = undefined;
+    const result = onDrag(100);
+    expect(result).toBe(false);
+  });
+
+  it("sets dragStartPos if undefined", () => {
+    dragStartLen.current = 50;
+    onDrag(100);
+    expect(dragStartPos.current).toBe(100);
+  });
+
+  it("updates length correctly", () => {
+    dragStartLen.current = 50;
+    dragStartPos.current = 100;
+
+    onDrag(80);
+    expect(currentLen).toBe(70); // 50 + (100 - 80)
+  });
+
+  it("respects minRatio and maxRatio", () => {
+    dragStartLen.current = 60;
+    dragStartPos.current = 120;
+
+    onDrag(195);
+    expect(currentLen).toBe(0);
+    onDrag(-500);
+    expect(currentLen).toBe(MAX_SIZE);
+  });
+
+  it("respects custom minRatio and maxRatio", () => {
+    setupCallback({ minRatio: 0.1, maxRatio: 0.9 });
+    dragStartLen.current = 55;
+    dragStartPos.current = 100;
+
+    onDrag(110);
+    expect(currentLen).toBe(50); // 0.1 * 500
+    onDrag(-500);
+    expect(currentLen).toBe(450); // 0.9 * 500
+  });
+
+  it("handles reverse dragging", () => {
+    setupCallback({ reverse: true });
+    dragStartLen.current = 50;
+    dragStartPos.current = 100;
+
+    onDrag(80);
+    expect(currentLen).toBe(30); // 50 - (100 - 80)
   });
 });

--- a/src/web/client/pages/library/base_reader.tsx
+++ b/src/web/client/pages/library/base_reader.tsx
@@ -46,7 +46,7 @@ interface SidebarConfig<CustomTabs> {
   showMobileNavSettings?: boolean;
 }
 /** Configuration for extra tabs to add to the sidebar or drawer. */
-export interface BaseExtraSidebarTabProps<CustomSidebarTab> {
+export interface BaseExtraSidebarTabProps<CustomSidebarTab> extends Responsive {
   tab: CustomSidebarTab;
 }
 /** Properties for the main column. */
@@ -182,7 +182,11 @@ export function BaseReader<
       ) : props.ExtraSidebarContent === undefined ? (
         <></>
       ) : (
-        <props.ExtraSidebarContent {...props} tab={sidebarTab} />
+        <props.ExtraSidebarContent
+          {...props}
+          tab={sidebarTab}
+          isMobile={isScreenSmall}
+        />
       )}
     </BaseLayout>
   );

--- a/src/web/client/pages/library/base_reader.tsx
+++ b/src/web/client/pages/library/base_reader.tsx
@@ -545,6 +545,7 @@ function BaseReaderLayout(props: NonMobileReaderLayoutProps): JSX.Element {
       <ResizingDragger
         currentLen={mainWidth()}
         setCurrentLen={(update) => setMainWidth(update(mainWidth()))}
+        reverse
         minRatio={0.2}
         maxRatio={0.8}
         getMax={() => containerWidth()}

--- a/src/web/client/pages/library/base_reader.tsx
+++ b/src/web/client/pages/library/base_reader.tsx
@@ -9,7 +9,6 @@ import {
   ReaderInternalTabConfig,
   isDefaultSidebarTab,
 } from "@/web/client/pages/library/reader_sidebar_components";
-import { StyleContext } from "@/web/client/styling/style_context";
 import React, {
   CSSProperties,
   PropsWithChildren,
@@ -49,12 +48,10 @@ interface SidebarConfig<CustomTabs> {
 /** Configuration for extra tabs to add to the sidebar or drawer. */
 export interface BaseExtraSidebarTabProps<CustomSidebarTab> {
   tab: CustomSidebarTab;
-  scale: number;
 }
 /** Properties for the main column. */
 export interface BaseMainColumnProps extends Responsive {
   onWordSelected: (word: string) => unknown;
-  scale: number;
 }
 interface ReaderExternalLayoutProps {
   swipeListeners?: SwipeListeners;
@@ -106,13 +103,6 @@ export function BaseReader<
   const isScreenSmall = useMediaQuery("(max-width: 900px)");
   const BaseLayout = isScreenSmall ? BaseMobileReaderLayout : BaseReaderLayout;
 
-  const {
-    readerMainScale,
-    setReaderMainScale,
-    readerSideScale,
-    setReaderSideScale,
-  } = React.useContext(StyleContext);
-
   const sidebarRef = React.useRef<HTMLDivElement>(null);
 
   const showDefaultTab = isDefaultSidebarTab(sidebarTab);
@@ -163,7 +153,6 @@ export function BaseReader<
       swipeListeners={swipeListeners}>
       <props.MainColumn
         {...props}
-        scale={readerMainScale}
         onWordSelected={onWordSelected}
         isMobile={isScreenSmall}
       />
@@ -176,11 +165,6 @@ export function BaseReader<
       {showDefaultTab ? (
         <DefaultReaderSidebarContent
           isSmallScreen={isScreenSmall}
-          scale={readerSideScale}
-          mainScale={readerMainScale}
-          setMainScale={setReaderMainScale}
-          sideScale={readerSideScale}
-          setSideScale={setReaderSideScale}
           {...(isScreenSmall && props.showMobileNavSettings
             ? {
                 swipeNavigation,
@@ -198,11 +182,7 @@ export function BaseReader<
       ) : props.ExtraSidebarContent === undefined ? (
         <></>
       ) : (
-        <props.ExtraSidebarContent
-          {...props}
-          tab={sidebarTab}
-          scale={readerSideScale}
-        />
+        <props.ExtraSidebarContent {...props} tab={sidebarTab} />
       )}
     </BaseLayout>
   );

--- a/src/web/client/pages/library/external_content_reader.tsx
+++ b/src/web/client/pages/library/external_content_reader.tsx
@@ -101,7 +101,6 @@ function MainColumn(props: BaseMainColumnProps) {
       callApi(LogClientEventApi, { name: "ExternalContentOpen" });
       if (isMobile) {
         window.scrollTo({ top: 0, behavior: "instant" });
-        window.scrollTo({ top: 64, behavior: "instant" });
       }
     },
     [setText, setCurrentTab, isMobile]

--- a/src/web/client/pages/library/library.test.tsx
+++ b/src/web/client/pages/library/library.test.tsx
@@ -27,14 +27,14 @@ mockCallApi.mockResolvedValue({
     {
       author: "Caesar",
       name: "DBG",
-      id: "DBG",
+      id: "phi002",
       urlAuthor: "caesar",
       urlName: "dbg",
     },
     {
       author: "Sallust",
       name: "Catalina",
-      id: "Catalina",
+      id: "phi001",
       urlAuthor: "sallust",
       urlName: "catalina",
     },
@@ -50,6 +50,19 @@ describe("library view", () => {
     await screen.findByText(/Caesar/);
     await screen.findByText(/Sallust/);
     await screen.findByText(/Catalina/);
+  });
+
+  it("allows filter by full id", async () => {
+    render(<Library />);
+    await screen.findByText(/Welcome/);
+
+    const search = screen.getByRole("combobox");
+    await user.click(search);
+    await user.type(search, "phi001");
+
+    expect(screen.queryByText("DBG")).toBeNull();
+    expect(screen.queryByText("Sallust")).not.toBeNull();
+    expect(screen.queryByText("Catalina")).not.toBeNull();
   });
 
   it("has working filter", async () => {

--- a/src/web/client/pages/library/library.test.tsx
+++ b/src/web/client/pages/library/library.test.tsx
@@ -79,7 +79,7 @@ describe("library view", () => {
 
     expect(mockNav).toHaveBeenCalledWith({
       path: "/work/caesar/dbg",
-      params: { pg: "1" },
+      params: {},
     });
   });
 

--- a/src/web/client/pages/library/library.test.tsx
+++ b/src/web/client/pages/library/library.test.tsx
@@ -38,6 +38,14 @@ mockCallApi.mockResolvedValue({
       urlAuthor: "sallust",
       urlName: "catalina",
     },
+    {
+      author: "BlahBLah",
+      name: "Translation",
+      id: "phi003",
+      urlAuthor: "blahh",
+      urlName: "blah",
+      isTranslation: true,
+    },
   ],
 });
 
@@ -46,10 +54,15 @@ describe("library view", () => {
     render(<Library />);
 
     await screen.findByText(/Welcome/);
-    await screen.findByText(/DBG/);
-    await screen.findByText(/Caesar/);
-    await screen.findByText(/Sallust/);
-    await screen.findByText(/Catalina/);
+
+    // Non-translations
+    expect(screen.queryByText("DBG")).not.toBeNull();
+    expect(screen.queryByText("Caesar")).not.toBeNull();
+    expect(screen.queryByText("Sallust")).not.toBeNull();
+    expect(screen.queryByText("Catalina")).not.toBeNull();
+    // Translations
+    expect(screen.queryByText("BlahBLah")).toBeNull();
+    expect(screen.queryByText("Translation")).toBeNull();
   });
 
   it("allows filter by full id", async () => {

--- a/src/web/client/pages/library/library.tsx
+++ b/src/web/client/pages/library/library.tsx
@@ -28,8 +28,7 @@ function onWorkSelected(work: LibraryWorkMetadata, nav: NavHelper<RouteInfo>) {
     return;
   }
   const saved = LibrarySavedSpot.get(work.id);
-  const [pg, id] = saved === undefined ? ["1", undefined] : [undefined, saved];
-  nav.to({ path, params: { pg, id } });
+  nav.to({ path, params: { id: saved } });
 }
 
 type WorkListState = "Loading" | "Error" | LibraryWorkMetadata[];

--- a/src/web/client/pages/library/library.tsx
+++ b/src/web/client/pages/library/library.tsx
@@ -24,14 +24,12 @@ const WORK_STYLE: React.CSSProperties = {
 function onWorkSelected(work: LibraryWorkMetadata, nav: NavHelper<RouteInfo>) {
   const params = { author: work.urlAuthor, name: work.urlName };
   const path = ClientPaths.WORK_BY_NAME.toUrlPath(params);
-  if (path !== null) {
-    const id = [work.name, work.author].join("@");
-    const saved = LibrarySavedSpot.get(id);
-    const useSectionId = typeof saved === "string";
-    const pg = useSectionId ? undefined : `${saved ?? 1}`;
-    const sectionId = useSectionId ? saved : undefined;
-    nav.to({ path, params: { pg, id: sectionId } });
+  if (path === null) {
+    return;
   }
+  const saved = LibrarySavedSpot.get(work.id);
+  const [pg, id] = saved === undefined ? ["1", undefined] : [undefined, saved];
+  nav.to({ path, params: { pg, id } });
 }
 
 type WorkListState = "Loading" | "Error" | LibraryWorkMetadata[];

--- a/src/web/client/pages/library/library.tsx
+++ b/src/web/client/pages/library/library.tsx
@@ -36,49 +36,56 @@ function WorksList(props: { works: WorkListState }) {
   const { nav } = Router.useRouter();
   const [filter, setFilter] = useState<string>("");
 
-  function shouldShowWork(work: LibraryWorkMetadata): boolean {
-    const query = filter.toLowerCase();
+  if (props.works === "Error") {
+    return <span className="text sm">Loading titles ...</span>;
+  }
+  if (props.works === "Loading") {
     return (
+      <span className="text sm">
+        Error loading titles. Check your internet and if the problem persists,
+        contact Morcus.
+      </span>
+    );
+  }
+
+  function shouldShowWork(work: LibraryWorkMetadata): boolean {
+    const query = filter.toLowerCase().trim();
+    return (
+      work.id === query ||
       work.author.toLowerCase().includes(query) ||
       work.name.toLowerCase().includes(query)
     );
   }
 
+  const filteredWorks = props.works.filter(shouldShowWork);
+
   return (
-    <>
-      {props.works === "Loading" ? (
-        <span className="text sm">Loading titles ...</span>
-      ) : props.works === "Error" ? (
-        <span className="text sm">
-          Error loading titles. Check your internet and if the problem persists,
-          contact Morcus.
-        </span>
-      ) : (
-        <div style={{ maxWidth: "400px", margin: "auto" }}>
-          <SearchBoxNoAutocomplete
-            onInput={setFilter}
-            placeholderText={SEARCH_PLACEHOLDER}
-            // Left and right are not equal to account for the border.
-            style={{ padding: "8px 12px 4px 8px" }}
-            ariaLabel={SEARCH_PLACEHOLDER}
-            autoFocused
-          />
-          {props.works.filter(shouldShowWork).map((work) => (
-            <div key={work.id}>
-              <SpanLink
-                id={work.id}
-                className="latWork"
-                onClick={() => onWorkSelected(work, nav)}>
-                <span style={WORK_STYLE}>{work.name}</span>
-                <span className="text sm light" style={WORK_STYLE}>
-                  {work.author}
-                </span>
-              </SpanLink>
-            </div>
-          ))}
+    <div style={{ maxWidth: "400px", margin: "auto" }}>
+      <SearchBoxNoAutocomplete
+        onInput={setFilter}
+        placeholderText={SEARCH_PLACEHOLDER}
+        // Left and right are not equal to account for the border.
+        style={{ padding: "8px 12px 4px 8px" }}
+        ariaLabel={SEARCH_PLACEHOLDER}
+        onRawEnter={() =>
+          filteredWorks.length === 1 && onWorkSelected(filteredWorks[0], nav)
+        }
+        autoFocused
+      />
+      {filteredWorks.map((work) => (
+        <div key={work.id}>
+          <SpanLink
+            id={work.id}
+            className="latWork"
+            onClick={() => onWorkSelected(work, nav)}>
+            <span style={WORK_STYLE}>{work.name}</span>
+            <span className="text sm light" style={WORK_STYLE}>
+              {work.author}
+            </span>
+          </SpanLink>
         </div>
-      )}
-    </>
+      ))}
+    </div>
   );
 }
 

--- a/src/web/client/pages/library/library.tsx
+++ b/src/web/client/pages/library/library.tsx
@@ -51,9 +51,10 @@ function WorksList(props: { works: WorkListState }) {
   function shouldShowWork(work: LibraryWorkMetadata): boolean {
     const query = filter.toLowerCase().trim();
     return (
-      work.id === query ||
-      work.author.toLowerCase().includes(query) ||
-      work.name.toLowerCase().includes(query)
+      !work.isTranslation &&
+      (work.id === query ||
+        work.author.toLowerCase().includes(query) ||
+        work.name.toLowerCase().includes(query))
     );
   }
 

--- a/src/web/client/pages/library/reader.test.tsx
+++ b/src/web/client/pages/library/reader.test.tsx
@@ -10,6 +10,7 @@ import { ReadingPage, SwipeFeedback } from "@/web/client/pages/library/reader";
 import { ClientPaths } from "@/web/client/routing/client_paths";
 import {
   ProcessedWork2,
+  type DocumentInfo,
   type NavTreeNode,
 } from "@/common/library/library_types";
 import { XmlNode } from "@/common/xml/xml_node";
@@ -41,6 +42,11 @@ window.scrollTo = jest.fn();
 
 const WORK_PAGE = ClientPaths.WORK_PAGE;
 const WORK_BY_NAME = ClientPaths.WORK_BY_NAME;
+const DBG_INFO: DocumentInfo = {
+  title: "DBG",
+  author: "Caesar",
+  workId: "dbg",
+};
 
 // @ts-ignore
 const mockCallApi: jest.Mock<any, any, any> = callApi;
@@ -64,7 +70,7 @@ const TWO_CHAPTER_NAV_TREE: NavTreeNode = {
   ],
 };
 const PROCESSED_WORK: ProcessedWork2 = {
-  info: { title: "DBG", author: "Caesar" },
+  info: DBG_INFO,
   textParts: ["chapter", "section"],
   rows: [
     [["1", "1"], new XmlNode("span", [], ["Gallia est omnis"])],
@@ -75,7 +81,7 @@ const PROCESSED_WORK: ProcessedWork2 = {
 };
 
 const WORK_WITH_NOTES: ProcessedWork2 = {
-  info: { title: "DBG", author: "Caesar" },
+  info: DBG_INFO,
   textParts: ["chapter", "section"],
   rows: [
     [
@@ -101,7 +107,7 @@ const WORK_WITH_NOTES: ProcessedWork2 = {
 };
 
 const WORK_WITH_FLAVOR_TEXT: ProcessedWork2 = {
-  info: { title: "DBG", author: "Caesar" },
+  info: DBG_INFO,
   textParts: ["chapter", "section"],
   rows: [
     [["1", "1"], new XmlNode("span", [], ["Gallia est omnis"])],
@@ -113,7 +119,7 @@ const WORK_WITH_FLAVOR_TEXT: ProcessedWork2 = {
 };
 
 const PROCESSED_WORK_MULTI_CHAPTER: ProcessedWork2 = {
-  info: { title: "DBG", author: "Caesar" },
+  info: DBG_INFO,
   textParts: ["chapter", "section"],
   rows: [
     [["1", "1"], new XmlNode("span", [], ["Gallia est omnis"])],
@@ -127,7 +133,7 @@ const PROCESSED_WORK_MULTI_CHAPTER: ProcessedWork2 = {
 };
 
 const PROCESSED_WORK_VARIANTS: ProcessedWork2 = {
-  info: { title: "DBG", author: "Caesar" },
+  info: DBG_INFO,
   textParts: ["chapter", "section"],
   rows: [
     [
@@ -601,12 +607,12 @@ describe("Reading UI", () => {
     await screen.findByText(/Drawer/);
   });
 
-  it("redirects on legacy page", async () => {
+  it("redirects on no id page", async () => {
     mockCallApi.mockResolvedValue(PROCESSED_WORK_MULTI_CHAPTER);
     const mockNav = jest.fn();
     const originalRoute: RouteInfo = {
       path: urlByIdFor("dbg"),
-      params: { pg: "2" },
+      params: {},
     };
 
     render(
@@ -624,7 +630,7 @@ describe("Reading UI", () => {
     const newRoute = mockNav.mock.calls[0][0](originalRoute);
     expect(newRoute).toStrictEqual({
       path: urlByIdFor("dbg"),
-      params: { id: "2" },
+      params: { id: "1" },
       replace: true,
     });
   });

--- a/src/web/client/pages/library/reader.test.tsx
+++ b/src/web/client/pages/library/reader.test.tsx
@@ -40,6 +40,13 @@ window.HTMLElement.prototype.scroll = jest.fn();
 window.HTMLElement.prototype.scrollTo = jest.fn();
 window.scrollTo = jest.fn();
 
+beforeAll(() => {
+  // js-dom doesn't yet support `dialog`.
+  HTMLDialogElement.prototype.show = jest.fn();
+  HTMLDialogElement.prototype.showModal = jest.fn();
+  HTMLDialogElement.prototype.close = jest.fn();
+});
+
 const WORK_PAGE = ClientPaths.WORK_PAGE;
 const WORK_BY_NAME = ClientPaths.WORK_BY_NAME;
 const DBG_INFO: DocumentInfo = {

--- a/src/web/client/pages/library/reader.test.tsx
+++ b/src/web/client/pages/library/reader.test.tsx
@@ -486,7 +486,8 @@ describe("Reading UI", () => {
     );
 
     await user.click(screen.queryByLabelText("Reader settings")!);
-    await screen.findByText(/Layout settings/);
+    await screen.findByText(/Main.+settings/);
+    expect(await screen.findAllByText(/Text size/)).toHaveLength(2);
   });
 
   it("shows page specified from URL", async () => {
@@ -580,7 +581,6 @@ describe("Reading UI", () => {
 
     await user.click(screen.queryByLabelText("Reader settings")!);
 
-    await screen.findByText(/Layout/);
     await screen.findByText(/Main column/);
     await screen.findByText(/Side column/);
   });

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -156,7 +156,7 @@ export function ReadingPage() {
       updatePage(1, nav, work, undefined, true);
     }
     // For reasons I don't understand, when we do the redirect the browser seems to
-    // put as at the bottom - to avoid this, premptively scroll to the top first.
+    // put us at the bottom - to avoid this, premptively scroll to the top first.
     window.scrollTo({ top: 0, behavior: "instant" });
   }, [work, urlLine, nav, findMatchPage]);
 

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/web/client/pages/library/reader/library_reader/library_reader_common";
 import { processWords } from "@/common/text_cleaning";
 import { checkPresent } from "@/common/assert";
+import { StyleContext } from "@/web/client/styling/style_context";
 
 const SPECIAL_ID_PARTS = new Set(["appendix", "prologus", "epilogus"]);
 
@@ -358,7 +359,6 @@ function WorkColumn(props: WorkColumnProps & BaseMainColumnProps) {
               <WorkTextPage
                 work={work}
                 page={currentPage}
-                textScale={props.scale}
                 isMobile={isMobile}
                 setDictWord={props.onWordSelected}
               />
@@ -481,18 +481,19 @@ function WorkNavigationBar(props: {
 export function WorkTextPage(props: {
   work: PaginatedWork;
   page: number;
-  textScale: number;
   isMobile: boolean;
   setDictWord: (work: string) => unknown;
 }) {
-  const { textScale, isMobile, work, setDictWord } = props;
+  const { isMobile, work, setDictWord } = props;
+
+  const { readerMainScale } = React.useContext(StyleContext);
   const { queryLine, highlightRef } = React.useContext(ReaderContext);
   const workColumnContext: WorkColumnContextType = React.useMemo(
     () => ({ setDictWord, work }),
     [setDictWord, work]
   );
 
-  const gapSize = (textScale / 100) * 0.65;
+  const gapSize = (readerMainScale / 100) * 0.65;
   const gap = `${gapSize}em`;
   const hasLines = work.textParts.slice(-1)[0].toLowerCase() === "line";
 

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -115,7 +115,6 @@ export function ReadingPage() {
   const highlightRef = React.useRef<HTMLSpanElement>(null);
 
   const { nav, route } = Router.useRouter();
-  const urlPg = safeParseInt(route.params?.pg);
   const urlId = route.params?.id;
   const urlLine = route.params?.l;
   const queryLine = safeParseInt(urlLine);
@@ -152,17 +151,14 @@ export function ReadingPage() {
     if (typeof work === "string") {
       return;
     }
-    if (urlPg !== undefined) {
-      // `pg` is the legacy parameter. This is just for backwards compatibility of old links.
-      updatePage(urlPg, nav, work, urlLine, true);
-    } else if (findMatchPage() === -1) {
+    if (findMatchPage() === -1) {
       // Handle invalid ids.
       updatePage(1, nav, work, undefined, true);
     }
     // For reasons I don't understand, when we do the redirect the browser seems to
     // put as at the bottom - to avoid this, premptively scroll to the top first.
     window.scrollTo({ top: 0, behavior: "instant" });
-  }, [urlPg, work, urlLine, nav, findMatchPage]);
+  }, [work, urlLine, nav, findMatchPage]);
 
   // Scroll to the required line, if specified.
   useEffect(() => {

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -794,6 +794,9 @@ function LatLink(props: { word: string }) {
 
 function renderTooltip(root: XmlNode): JSX.Element {
   const style: React.CSSProperties = {};
+  if (root.name === "br") {
+    return <br />;
+  }
   const rend = root.getAttr("rend");
   if (rend === "italic") {
     style.fontStyle = "italic";
@@ -803,6 +806,9 @@ function renderTooltip(root: XmlNode): JSX.Element {
   }
   if (rend === "sup") {
     style.verticalAlign = "super";
+  }
+  if (root.getAttr("block") === "1") {
+    style.display = "block";
   }
   return (
     <span style={style}>

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -691,6 +691,7 @@ function WorkInfo(props: { workInfo: DocumentInfo }) {
         {props.workInfo.sponsor && (
           <InfoLine label="Sponsor" value={props.workInfo.sponsor} />
         )}
+        <InfoLine label="ID" value={props.workInfo.workId} />
       </div>
       <div style={{ lineHeight: 1, marginTop: "8px" }}>
         <span className="text sm light">

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -856,6 +856,9 @@ function displayForLibraryChunk(
   if (root.name === "note") {
     return <TextNote key={key} node={root} />;
   }
+  if (root.name === "space") {
+    return <></>;
+  }
 
   const style: React.CSSProperties = {};
   let className: string | undefined = undefined;

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -829,7 +829,7 @@ function TextNote(props: { node: XmlNode }) {
   return (
     note && (
       <ClickableTooltip
-        titleText={renderTooltip(note)}
+        titleText={<div className="text sm">{renderTooltip(note)}</div>}
         ChildFactory={TextNoteContent}
         visibleListener={(isOpen) => {
           if (isOpen) {

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -571,8 +571,12 @@ function WorkTextColumn(props: {
       style={{ gridColumn: 2, gridRow: props.gridRow }}
       id={props.id}
       className={props.className}>
-      {displayForLibraryChunk(props.content)}
-      {"\n" /* Add a newline so copy / paste works correctly on Firefox. */}
+      <span style={{ whiteSpace: "normal" }}>
+        {displayForLibraryChunk(props.content)}
+      </span>
+      {
+        "\n" /* Add a newline out of the `whiteSpace: normal` so copy / paste works correctly on Firefox. */
+      }
     </span>
   );
 }
@@ -788,9 +792,19 @@ function LatLink(props: { word: string }) {
 }
 
 function renderTooltip(root: XmlNode): JSX.Element {
-  const italic = root.getAttr("rend") === "italic";
+  const style: React.CSSProperties = {};
+  const rend = root.getAttr("rend");
+  if (rend === "italic") {
+    style.fontStyle = "italic";
+  }
+  if (rend === "overline") {
+    style.textDecoration = "overline";
+  }
+  if (rend === "sup") {
+    style.verticalAlign = "super";
+  }
   return (
-    <span style={{ fontStyle: italic ? "italic" : undefined }}>
+    <span style={style}>
       {root.children.map((c) => (typeof c === "string" ? c : renderTooltip(c)))}
     </span>
   );

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -882,7 +882,7 @@ function displayForLibraryChunk(
   if (root.getAttr("l") !== undefined) {
     className = "l";
   }
-  if (["s", "b"].includes(root.name)) {
+  if (["s", "b", "ul", "li"].includes(root.name)) {
     return React.createElement(root.name, { key, style }, children);
   }
   switch (root.name) {

--- a/src/web/client/pages/library/reader/library_reader/library_reader_common.tsx
+++ b/src/web/client/pages/library/reader/library_reader/library_reader_common.tsx
@@ -24,6 +24,5 @@ export function navigateToSection(
   const isOneColumn = twoColumnMain === null;
   const container = isOneColumn ? window : twoColumnMain;
   container?.scrollTo({ top: isOneColumn ? 64 : 0, behavior: "instant" });
-  const id = [work.info.title, work.info.author].join("@");
-  LibrarySavedSpot.set(id, sectionId);
+  LibrarySavedSpot.set(work.info.workId, sectionId);
 }

--- a/src/web/client/pages/library/reader/library_reader/library_reader_common.tsx
+++ b/src/web/client/pages/library/reader/library_reader/library_reader_common.tsx
@@ -23,6 +23,6 @@ export function navigateToSection(
   const twoColumnMain = document.getElementById(LARGE_VIEW_MAIN_COLUMN_ID);
   const isOneColumn = twoColumnMain === null;
   const container = isOneColumn ? window : twoColumnMain;
-  container?.scrollTo({ top: isOneColumn ? 64 : 0, behavior: "instant" });
+  container?.scrollTo({ top: 0, behavior: "instant" });
   LibrarySavedSpot.set(work.info.workId, sectionId);
 }

--- a/src/web/client/pages/library/reader_sidebar_components.tsx
+++ b/src/web/client/pages/library/reader_sidebar_components.tsx
@@ -136,16 +136,13 @@ export function ReaderSettings(props: ReaderSettingsProps) {
   const {
     totalWidth,
     setTotalWidth,
-    mainWidth,
-    setMainWidth,
     mainScale,
     setMainScale,
     sideScale,
     setSideScale,
   } = props;
   const hasTotalWidth = totalWidth !== undefined && setTotalWidth !== undefined;
-  const hasMainWidth = mainWidth !== undefined && setMainWidth !== undefined;
-  const hasLayoutSettings = hasTotalWidth || hasMainWidth;
+  const hasLayoutSettings = hasTotalWidth;
   const mainLabel = hasLayoutSettings ? "Main column" : "Main panel";
   const sideLabel = hasLayoutSettings ? "Side column" : "Drawer";
   return (
@@ -163,16 +160,6 @@ export function ReaderSettings(props: ReaderSettingsProps) {
               min={0}
               max={3}
               step={1}
-            />
-          )}
-          {hasMainWidth && (
-            <NumberSelector
-              value={mainWidth}
-              setValue={setMainWidth}
-              label="Main width"
-              min={32}
-              max={80}
-              step={8}
             />
           )}
         </details>

--- a/src/web/client/pages/library/reader_sidebar_components.tsx
+++ b/src/web/client/pages/library/reader_sidebar_components.tsx
@@ -108,19 +108,7 @@ export function MobileReaderSettingsSections(props: MobileReaderSettings) {
   );
 }
 
-export interface DesktopReaderSettings {
-  /** The total width setting for the reader. */
-  totalWidth?: number;
-  /** A setter for the total width of the reader. */
-  setTotalWidth?: (width: number) => unknown;
-  /** The width of the main column of the reader. */
-  mainWidth?: number;
-  /** A setter for the width of the main column of the reader. */
-  setMainWidth?: (width: number) => unknown;
-}
-export interface ReaderSettingsProps
-  extends DesktopReaderSettings,
-    MobileReaderSettings {
+export interface ReaderSettingsProps extends MobileReaderSettings {
   /** The scale to use for the elements in the reader. */
   scale: number;
   /** The scale of the main column of the reader. */
@@ -131,39 +119,16 @@ export interface ReaderSettingsProps
   sideScale: number;
   /** A setter for the scale of the side column of the reader. */
   setSideScale: (width: number) => unknown;
+  /** Whether the reader is a small screen. */
+  isSmallScreen: boolean;
 }
 export function ReaderSettings(props: ReaderSettingsProps) {
-  const {
-    totalWidth,
-    setTotalWidth,
-    mainScale,
-    setMainScale,
-    sideScale,
-    setSideScale,
-  } = props;
-  const hasTotalWidth = totalWidth !== undefined && setTotalWidth !== undefined;
-  const hasLayoutSettings = hasTotalWidth;
-  const mainLabel = hasLayoutSettings ? "Main column" : "Main panel";
-  const sideLabel = hasLayoutSettings ? "Side column" : "Drawer";
+  const { mainScale, setMainScale, sideScale, setSideScale, isSmallScreen } =
+    props;
+  const mainLabel = isSmallScreen ? "Main panel" : "Main column";
+  const sideLabel = isSmallScreen ? "Drawer" : "Side column";
   return (
     <>
-      {hasLayoutSettings && (
-        <details open>
-          <summary>
-            <SettingsText message="Layout settings" />
-          </summary>
-          {hasTotalWidth && (
-            <NumberSelector
-              value={totalWidth}
-              setValue={setTotalWidth}
-              label="Total width"
-              min={0}
-              max={3}
-              step={1}
-            />
-          )}
-        </details>
-      )}
       <MobileReaderSettingsSections {...props} />
       <details open>
         <summary>

--- a/src/web/client/pages/library/reader_sidebar_components.tsx
+++ b/src/web/client/pages/library/reader_sidebar_components.tsx
@@ -7,6 +7,8 @@ import {
 import { exhaustiveGuard } from "@/common/misc_utils";
 import { NumberSelector } from "@/web/client/components/generic/selectors";
 import { SvgIcon } from "@/web/client/components/generic/icons";
+import { StyleContext } from "@/web/client/styling/style_context";
+import { useContext } from "react";
 
 export interface EmbeddedDictionaryProps {
   /** The word to look up in the dictionary, if any. */
@@ -16,8 +18,6 @@ export interface EmbeddedDictionaryProps {
    * within the embedded dictionary request a new word.
    */
   setDictWord: (word: string) => unknown;
-  /** The scale (for display size) to use for the dictionary. */
-  scale: number;
   /**
    * The message to display in the instruction text for the dictionary.
    * This should instruct the user what action to perform on a word in
@@ -29,6 +29,7 @@ export interface EmbeddedDictionaryProps {
 export function EmbeddedDictionary(
   props: EmbeddedDictionaryProps
 ): JSX.Element {
+  const styles = useContext(StyleContext);
   const action = props.dictActionMessage || "Click on";
   return props.dictWord === undefined ? (
     <InfoText
@@ -38,7 +39,7 @@ export function EmbeddedDictionary(
     <DictionaryViewV2
       embedded
       initial={props.dictWord}
-      textScale={props.scale}
+      textScale={styles.readerSideScale}
       embeddedOptions={{ hideableOutline: true }}
       setInitial={props.setDictWord}
     />
@@ -109,22 +110,13 @@ export function MobileReaderSettingsSections(props: MobileReaderSettings) {
 }
 
 export interface ReaderSettingsProps extends MobileReaderSettings {
-  /** The scale to use for the elements in the reader. */
-  scale: number;
-  /** The scale of the main column of the reader. */
-  mainScale: number;
-  /** A setter for the scale of the main column of the reader. */
-  setMainScale: (width: number) => unknown;
-  /** The scale of the side column of the reader. */
-  sideScale: number;
-  /** A setter for the scale of the side column of the reader. */
-  setSideScale: (width: number) => unknown;
   /** Whether the reader is a small screen. */
   isSmallScreen: boolean;
 }
 export function ReaderSettings(props: ReaderSettingsProps) {
-  const { mainScale, setMainScale, sideScale, setSideScale, isSmallScreen } =
-    props;
+  const { isSmallScreen } = props;
+  const styles = useContext(StyleContext);
+
   const mainLabel = isSmallScreen ? "Main panel" : "Main column";
   const sideLabel = isSmallScreen ? "Drawer" : "Side column";
   return (
@@ -135,8 +127,8 @@ export function ReaderSettings(props: ReaderSettingsProps) {
           <SettingsText message={`${mainLabel} settings`} />
         </summary>
         <NumberSelector
-          value={mainScale}
-          setValue={setMainScale}
+          value={styles.readerMainScale}
+          setValue={styles.setReaderMainScale}
           label="Text size"
           tag={mainLabel}
           min={50}
@@ -149,8 +141,8 @@ export function ReaderSettings(props: ReaderSettingsProps) {
           <SettingsText message={`${sideLabel} settings`} />
         </summary>
         <NumberSelector
-          value={sideScale}
-          setValue={setSideScale}
+          value={styles.readerSideScale}
+          setValue={styles.setReaderSideScale}
           label="Text size"
           tag={sideLabel}
           min={50}
@@ -254,7 +246,6 @@ export function DefaultReaderSidebarContent(
             props.setCurrentTab("Dictionary");
             props.setDictWord(target);
           }}
-          scale={props.sideScale}
           dictActionMessage={props.dictActionMessage}
         />
       );

--- a/src/web/client/pages/library/saved_spots.test.tsx
+++ b/src/web/client/pages/library/saved_spots.test.tsx
@@ -21,5 +21,9 @@ describe("LibrarySaveSpot", () => {
 
     expect(LibrarySavedSpot.get("foo.bar")).toBe("8");
     expect(LibrarySavedSpot.get("bar.baz")).toBe("7");
+    expect(LibrarySavedSpot.getAll()).toStrictEqual({
+      "foo.bar": { sectionId: "8" },
+      "bar.baz": { sectionId: "7" },
+    });
   });
 });

--- a/src/web/client/pages/library/saved_spots.ts
+++ b/src/web/client/pages/library/saved_spots.ts
@@ -1,23 +1,29 @@
-import { safeParseInt } from "@/common/misc_utils";
+const SAVED_SPOTS_KEY = "LIBRARY_SPOTS";
 
-const SAVED_SPOTS_KEY_PREFIX = "LIBRARY_SPOT_";
+interface SavedSpotEntry {
+  sectionId: string;
+}
 
-const getKey = (id: string, v: string) => SAVED_SPOTS_KEY_PREFIX + v + id;
+interface SavedSpotData {
+  [workId: string]: SavedSpotEntry;
+}
 
 export namespace LibrarySavedSpot {
-  export function get(id: string): number | string | undefined {
-    const stored = localStorage.getItem(getKey(id, "V2"));
+  export function getAll(): SavedSpotData {
+    const stored = localStorage.getItem(SAVED_SPOTS_KEY);
     if (stored !== null) {
       return JSON.parse(stored);
     }
-    const v1 = localStorage.getItem(getKey(id, "V1"));
-    if (v1 === null) {
-      return undefined;
-    }
-    return safeParseInt(JSON.parse(v1));
+    return {};
   }
 
-  export function set(id: string, sectionId: string): void {
-    localStorage.setItem(getKey(id, "V2"), JSON.stringify(sectionId));
+  export function get(workId: string): string | undefined {
+    return getAll()[workId]?.sectionId;
+  }
+
+  export function set(workId: string, sectionId: string): void {
+    const spots = getAll();
+    spots[workId] = { sectionId };
+    localStorage.setItem(SAVED_SPOTS_KEY, JSON.stringify(spots));
   }
 }

--- a/src/web/client/styling/styles.tsx
+++ b/src/web/client/styling/styles.tsx
@@ -160,6 +160,12 @@ export function getGlobalStyles(settings: StyleConfig): Interpolation<object> {
     "button:is(:hover, :focus-visible):not(:disabled)": {
       backgroundColor: "rgba(0, 0, 0, 0.075)",
     },
+    "button.outline": {
+      borderRadius: "4px",
+      backgroundColor: `${theme.bgAlt}20`,
+      padding: "4px 8px",
+      border: `2px solid ${theme.bgAlt}`,
+    },
     ".button": {
       borderRadius: 4,
       cursor: "pointer",

--- a/src/web/client/styling/styles.tsx
+++ b/src/web/client/styling/styles.tsx
@@ -149,6 +149,17 @@ export function getGlobalStyles(settings: StyleConfig): Interpolation<object> {
     },
 
     // Buttons
+    button: {
+      backgroundColor: "transparent",
+      border: "none",
+      margin: 0,
+      padding: 0,
+      cursor: "pointer",
+      outline: "none",
+    },
+    "button:is(:hover, :focus-visible):not(:disabled)": {
+      backgroundColor: "rgba(0, 0, 0, 0.075)",
+    },
     ".button": {
       borderRadius: 4,
       cursor: "pointer",
@@ -217,48 +228,33 @@ export function getGlobalStyles(settings: StyleConfig): Interpolation<object> {
     ".iconButton:disabled": {
       color: contentTextColor + "20",
     },
-    ".iconButton:is(:hover, :focus-visible):not(:disabled)": {
-      backgroundColor: "rgba(0, 0, 0, 0.075)",
-    },
 
     // Modals
-    ".modalOverlay": {
-      display: "block",
-      height: "100vh",
-      width: "100%",
-      left: 0,
-      top: 0,
-      backgroundColor: "#00000080",
-      position: "fixed",
-      zIndex: 100,
+    dialog: {
+      border: "none",
+      padding: 0,
     },
-    ".drawer .contentHolder": {
-      position: "fixed",
-      height: "100vh",
-      top: 0,
-      left: 0,
-      zIndex: 101,
-      transform: "translateX(-100%);",
+    "dialog::backdrop": {
+      backgroundColor: "#00000080",
+    },
+    // Dialog modals
+    "dialog.dialogModal": {
+      borderRadius: "8px",
+      width: "400px",
+      // This is animated: see `@starting-style`.
+      opacity: 1,
+      transition: "opacity 0.25s ease-out",
+    },
+    // Drawer
+    "dialog.drawer": {
+      margin: 0,
+      maxHeight: "100vh",
+      height: "100%",
+      // This is animated: see `@starting-style`.
+      transform: "translateX(0)",
       transition: "transform 0.14s ease-out;",
     },
-    ".drawer .contentHolder.open": {
-      transform: "translateX(0);",
-    },
-    ".dialogModal .contentHolder ": {
-      position: "fixed",
-      maxWidth: "80vw",
-      top: "50vh",
-      left: "50vw",
-      zIndex: 101,
-      borderRadius: "8px",
-      transform: "translate(-50%, -60%)",
-      transition: "opacity 0.25s ease-out;",
-      width: "400px",
-      opacity: 0,
-    },
-    ".dialogModal .contentHolder.open": {
-      opacity: 1,
-    },
+    // Contents.
     ".dialogActions": {
       display: "flex",
       alignItems: "center",
@@ -675,15 +671,6 @@ export function getGlobalStyles(settings: StyleConfig): Interpolation<object> {
     ".readerMain .blockquote .l": {
       display: "block",
     },
-    // TODO: Eventually we can delete `SpanButton` and just use this.
-    ".readerMain button": {
-      backgroundColor: "transparent",
-      border: "none",
-      margin: 0,
-      padding: 0,
-      cursor: "pointer",
-      outline: "none",
-    },
     ".customSearchPopup": {
       color: theme.searchPopupText,
       backgroundColor: theme.searchPopupBg,
@@ -756,6 +743,15 @@ export function getGlobalStyles(settings: StyleConfig): Interpolation<object> {
       },
       "::-webkit-scrollbar-thumb": {
         borderRadius: "4px",
+      },
+    },
+    // For reasons I don't understand, this has to be at the bottom.
+    "@starting-style": {
+      "dialog[open].dialogModal": {
+        opacity: 0,
+      },
+      "dialog[open].drawer": {
+        transform: "translateX(-100%)",
       },
     },
   };

--- a/src/web/client/styling/styles.tsx
+++ b/src/web/client/styling/styles.tsx
@@ -671,8 +671,6 @@ export function getGlobalStyles(settings: StyleConfig): Interpolation<object> {
       margin: "0.25em 0",
       fontStyle: "italic",
       marginLeft: "1em",
-      // Override from `text`.
-      whiteSpace: "normal",
     },
     ".readerMain .blockquote .l": {
       display: "block",

--- a/src/web/client/styling/styles.tsx
+++ b/src/web/client/styling/styles.tsx
@@ -344,11 +344,13 @@ export function getGlobalStyles(settings: StyleConfig): Interpolation<object> {
       boxShadow:
         "rgba(0, 0, 0, 0.2) 0px 2px 4px -1px, rgba(0, 0, 0, 0.14) 0px 4px 5px 0px, rgba(0, 0, 0, 0.12) 0px 1px 10px 0px;",
     },
-    ".menuItemActive": {
-      color: theme.menuItemBase + theme.menuItemActiveAlpha,
-    },
-    ".menuItemInactive": {
+
+    ".menuItem": {
       color: theme.menuItemBase + theme.menuItemInactiveAlpha,
+      fontWeight: "bold",
+    },
+    ".menuItem.active": {
+      color: theme.menuItemBase + theme.menuItemActiveAlpha,
     },
 
     /** Dictionary specific */

--- a/src/web/client/styling/styles.tsx
+++ b/src/web/client/styling/styles.tsx
@@ -321,11 +321,9 @@ export function getGlobalStyles(settings: StyleConfig): Interpolation<object> {
     },
     ".Container": {
       boxSizing: "border-box",
-      marginLeft: "auto",
-      marginRight: "auto",
       display: "block",
-      paddingLeft: "16px",
-      paddingRight: "16px",
+      padding: "0 16px",
+      margin: "0 auto",
     },
 
     /** Menu and menu items */


### PR DESCRIPTION
- Library QOL features (fix some bugs in saved spot handling, and allow enter-to-select in lib search)
- resizable panels in the reader (total width and main width)
- enable inflection by default
- pre-compressed brotli (Saves 15 kB!)
- Res Gestae (Marcellinus)
- Support line groups
- Remove `FocusTrap` and use the built-in `dialog` instead.