### PR TITLE
fix: Preact types

### DIFF
--- a/src/web/client/components/generic/basics.tsx
+++ b/src/web/client/components/generic/basics.tsx
@@ -150,7 +150,7 @@ export function TextField(props: {
   const baseProps = {
     id: props.id,
     className: "text md textField",
-    spellCheck: false,
+    spellcheck: false,
     autoCapitalize: "none",
     autoComplete: "off",
     defaultValue: props.defaultValue,

--- a/src/web/client/components/generic/basics.tsx
+++ b/src/web/client/components/generic/basics.tsx
@@ -145,7 +145,7 @@ export function TextField(props: {
     onNewValue === undefined
       ? undefined
       : (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-          onNewValue(e.target.value);
+          onNewValue(e.currentTarget.value);
   const width = "calc(100% - 12px)";
   const baseProps = {
     id: props.id,

--- a/src/web/client/components/generic/overlays.tsx
+++ b/src/web/client/components/generic/overlays.tsx
@@ -3,7 +3,7 @@ import {
   SpanButton,
   type ClickableCoreProps,
 } from "@/web/client/components/generic/basics";
-import { PropsWithChildren, useEffect, useRef } from "react";
+import { PropsWithChildren, useEffect, useRef, JSX } from "react";
 
 export type OverlayProps = ClickableCoreProps;
 

--- a/src/web/client/components/generic/search.tsx
+++ b/src/web/client/components/generic/search.tsx
@@ -173,7 +173,7 @@ export function SearchBox<T>(props: SearchBoxProps<T>) {
             autoComplete="off"
             aria-label={props.ariaLabel}
             value={input}
-            onChange={async (e) => onInput(e.target.value)}
+            onChange={async (e) => onInput(e.currentTarget.value)}
             onKeyUp={(event) => {
               if (event.key !== "Enter") {
                 return;

--- a/src/web/client/components/generic/search.tsx
+++ b/src/web/client/components/generic/search.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState, useEffect, JSX } from "react";
 
 import Popper from "@mui/base/PopperUnstyled";
 import { IconButton, SvgIcon } from "@/web/client/components/generic/icons";

--- a/src/web/client/components/generic/search.tsx
+++ b/src/web/client/components/generic/search.tsx
@@ -168,7 +168,7 @@ export function SearchBox<T>(props: SearchBoxProps<T>) {
             ref={inputRef}
             type="text"
             className="customSearchBox text md"
-            spellCheck="false"
+            spellcheck={false}
             autoCapitalize="none"
             autoComplete="off"
             aria-label={props.ariaLabel}

--- a/src/web/client/components/single_page_app.tsx
+++ b/src/web/client/components/single_page_app.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect } from "react";
+import { useState, useContext, useEffect, JSX } from "react";
 
 import { ResponsiveAppBar } from "@/web/client/components/app_bar";
 import { ReportIssueDialog } from "@/web/client/components/report_issue_dialog";

--- a/src/web/client/offline/offline_settings_ui.tsx
+++ b/src/web/client/offline/offline_settings_ui.tsx
@@ -88,7 +88,7 @@ function OfflineSettingsCheckbox(props: {
           checked={setting === true}
           disabled={disabled}
           onChange={async (e) => {
-            const checked = e.target.checked;
+            const checked = e.currentTarget.checked;
             setProgress("In progress: please wait");
             const status = await registerServiceWorker();
             if (status === -1) {

--- a/src/web/client/pages/dictionary/dictionary_utils.test.tsx
+++ b/src/web/client/pages/dictionary/dictionary_utils.test.tsx
@@ -6,7 +6,7 @@ import { XmlNode } from "@/common/xml/xml_node";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import user from "@testing-library/user-event";
-import { forwardRef } from "react";
+import { forwardRef, JSX } from "react";
 
 import {
   ClickableTooltip,

--- a/src/web/client/pages/dictionary/dictionary_utils.tsx
+++ b/src/web/client/pages/dictionary/dictionary_utils.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { JSX } from "react";
 
 import { checkPresent } from "@/common/assert";
 import { XmlNode } from "@/common/xml/xml_node";

--- a/src/web/client/pages/dictionary/search/dictionary_search.tsx
+++ b/src/web/client/pages/dictionary/search/dictionary_search.tsx
@@ -96,7 +96,7 @@ function SearchSettingsDialog(props: {
                 disabled={shouldDisable[dict.key]}
                 onChange={(e) => {
                   const dicts = new Set(props.dicts);
-                  if (e.target.checked) {
+                  if (e.currentTarget.checked) {
                     dicts.add(dict);
                   } else {
                     dicts.delete(dict);

--- a/src/web/client/pages/library/base_reader.tsx
+++ b/src/web/client/pages/library/base_reader.tsx
@@ -15,6 +15,7 @@ import React, {
   useEffect,
   useState,
   useCallback,
+  JSX,
 } from "react";
 import { ContentBox } from "@/web/client/pages/dictionary/sections";
 import { Footer } from "@/web/client/components/footer";

--- a/src/web/client/pages/library/external_content_reader.tsx
+++ b/src/web/client/pages/library/external_content_reader.tsx
@@ -8,7 +8,7 @@ import {
   ReaderInternalTabConfig,
 } from "@/web/client/pages/library/reader_sidebar_components";
 
-import { PropsWithChildren, useEffect, useState } from "react";
+import { PropsWithChildren, useEffect, useState, JSX } from "react";
 import { exhaustiveGuard } from "@/common/misc_utils";
 import React from "react";
 import { ContentBox } from "@/web/client/pages/dictionary/sections";

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -516,7 +516,7 @@ function JumpToSection() {
         className="bgColor text"
         aria-label="jump to id"
         value={value}
-        onChange={(e) => setValue(e.target.value ?? "")}
+        onChange={(e) => setValue(e.currentTarget.value ?? "")}
         onKeyUp={(e) => {
           if (e.key === "Enter" && value.length > 0) {
             nav.to((old) => ({

--- a/src/web/client/pages/library/reader.tsx
+++ b/src/web/client/pages/library/reader.tsx
@@ -9,7 +9,7 @@ import { XmlNode } from "@/common/xml/xml_node";
 import { ContentBox } from "@/web/client/pages/dictionary/sections";
 import { ClientPaths } from "@/web/client/routing/client_paths";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, JSX } from "react";
 import * as React from "react";
 import {
   areArraysEqual,

--- a/src/web/client/pages/library/reader_sidebar_components.tsx
+++ b/src/web/client/pages/library/reader_sidebar_components.tsx
@@ -84,7 +84,7 @@ export function MobileReaderSettingsSections(props: MobileReaderSettings) {
             id="swipeNav"
             name="swipeNav"
             checked={swipeNavigation}
-            onChange={(e) => setSwipeNavigation(e.target.checked)}
+            onChange={(e) => setSwipeNavigation(e.currentTarget.checked)}
           />
           <label htmlFor="swipeNav" className="text md">
             Swipe to change page
@@ -98,7 +98,7 @@ export function MobileReaderSettingsSections(props: MobileReaderSettings) {
             id="tapNav"
             name="tapNav"
             checked={tapNavigation}
-            onChange={(e) => setTapNavigation(e.target.checked)}
+            onChange={(e) => setTapNavigation(e.currentTarget.checked)}
           />
           <label htmlFor="tapNav" className="text md">
             Tap edge to change page [Beta]

--- a/src/web/client/pages/library/reader_sidebar_components.tsx
+++ b/src/web/client/pages/library/reader_sidebar_components.tsx
@@ -8,7 +8,7 @@ import { exhaustiveGuard } from "@/common/misc_utils";
 import { NumberSelector } from "@/web/client/components/generic/selectors";
 import { SvgIcon } from "@/web/client/components/generic/icons";
 import { StyleContext } from "@/web/client/styling/style_context";
-import { useContext } from "react";
+import { useContext, JSX } from "react";
 
 export interface EmbeddedDictionaryProps {
   /** The word to look up in the dictionary, if any. */

--- a/src/web/client/pages/library/reader_utils.tsx
+++ b/src/web/client/pages/library/reader_utils.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { CSSProperties } from "react";
+import { CSSProperties, JSX } from "react";
 import { IconButton, SvgIcon } from "@/web/client/components/generic/icons";
 
 export function SettingsText(props: { message: string }) {

--- a/src/web/client/pages/site_settings.tsx
+++ b/src/web/client/pages/site_settings.tsx
@@ -38,7 +38,7 @@ function DropDown(props: {
       <select
         name={props.id}
         id={props.id}
-        onChange={(e) => props.onSelected(e.target.value)}
+        onChange={(e) => props.onSelected(e.currentTarget.value)}
         defaultValue={props.default}>
         {props.options.map((o) => (
           <option value={o} key={o}>

--- a/src/web/client/pages/tooltips.tsx
+++ b/src/web/client/pages/tooltips.tsx
@@ -1,5 +1,5 @@
 import Popper from "@mui/base/PopperUnstyled";
-import React, { RefObject } from "react";
+import React, { RefObject, JSX } from "react";
 import { exhaustiveGuard, singletonOf } from "@/common/misc_utils";
 import { RouteInfo } from "@/web/client/router/router_v2";
 import { ClientPaths } from "@/web/client/routing/client_paths";

--- a/src/web/client/router/paths.ts
+++ b/src/web/client/router/paths.ts
@@ -1,3 +1,5 @@
+import { JSX } from "react";
+
 export interface ContentPage {
   /** The content to display for this page. */
   Content: (props: Partial<Record<string, any>>) => JSX.Element;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
     // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    "jsxImportSource": "preact",                         /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
     // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
@@ -36,10 +36,10 @@
       "@/*": [
         "*"
       ],
-      "react": ["./node_modules/preact/compat/"],
-      "react/jsx-runtime": ["./node_modules/preact/jsx-runtime"],
-      "react-dom": ["./node_modules/preact/compat/"],
-      "react-dom/*": ["./node_modules/preact/compat/*"]
+      "react": ["../node_modules/preact/compat/"],
+      "react/jsx-runtime": ["../node_modules/preact/jsx-runtime"],
+      "react-dom": ["../node_modules/preact/compat/"],
+      "react-dom/*": ["../node_modules/preact/compat/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */


### PR DESCRIPTION
Re: https://github.com/preactjs/preact-www/issues/1240

1. Fixes the paths in the `tsconfig.json`, which were copied w/out accounting for the set `baseUrl`
2. Preact doesn't provide `JSX` as a global type as this conflicts & clashes with all other JSX configurations. React recently stopped providing this as a global too.
3. Switch to `event.currentTarget`. This is certainly what you want, there's no guarantees the original `target` the user interacts with still exists & so it can be `null` by the time your listener goes to use it. React's synthetic event system deviates from the DOM so their types deviate from from platform behavior a bit.
4. Switch to `.spellcheck`. While we support some of React's made up property cases, we're generally trying to cut back on that. `.spellcheck` is the native DOM casing and therefore the casing we support. `.spellCheck` will intentionally fail type checks, though at runtime it'll usually work (but it'll be set as an attribute, not as a property).

Fixed Upstream:

1. Preact was missing types for `auxclick` events: https://github.com/preactjs/preact/pull/4672
2. Preact wasn't exposing `AriaAttributes` from compat: https://github.com/preactjs/preact/pull/4673
3. Preact wasn't exposing `EventHandler` from compat: https://github.com/preactjs/preact/pull/4674
4. Preact was missing a type for `ForwardRefRenderFunction`: https://github.com/preactjs/preact/pull/4675

---

There's still a few type errors (excluding those which need a new Preact release, but that'll be in the next few days likely) that I don't quite know how to fix or if they're even Preact errors.