### PR TITLE
Update the Rust Autocompleter to use owned data.

### DIFF
--- a/morceus_rust/src/completions.rs
+++ b/morceus_rust/src/completions.rs
@@ -4,6 +4,8 @@ mod find_matches;
 mod stem_and_irreg_ranges;
 mod string_utils;
 
+use std::borrow::Cow;
+
 use crate::{
     completions::{
         autocomplete_result::{IrregResult, StemResult},
@@ -14,13 +16,13 @@ use crate::{
 };
 
 /// The main entry point for completions.
-pub struct Autocompleter {
-    tables: CruncherTables,
+pub struct Autocompleter<'t> {
+    tables: Cow<'t, CruncherTables>,
     addenda: Addenda,
     default_options: AutompleterOptions,
 }
 
-impl Autocompleter {
+impl Autocompleter<'_> {
     /// Creates an autocompleter with the given options.
     ///
     /// # Arguments
@@ -29,10 +31,10 @@ impl Autocompleter {
     ///   To create tables, from the `morcus-net` repo root, run:
     ///   `./morcus.sh build --morceus_tables`
     /// * `default_options` - Default options for the autocompleter.
-    pub fn new(
-        tables: CruncherTables,
+    pub fn new<'t>(
+        tables: Cow<'t, CruncherTables>,
         default_options: AutompleterOptions,
-    ) -> Result<Autocompleter, AutocompleteError> {
+    ) -> Result<Autocompleter<'t>, AutocompleteError> {
         Ok(Autocompleter {
             addenda: Autocompleter::make_addenda(&tables)?,
             tables,

--- a/morceus_rust/src/completions.rs
+++ b/morceus_rust/src/completions.rs
@@ -14,13 +14,13 @@ use crate::{
 };
 
 /// The main entry point for completions.
-pub struct Autocompleter<'o> {
+pub struct Autocompleter {
     tables: CruncherTables,
     addenda: Addenda,
-    options: &'o AutompleterOptions,
+    default_options: AutompleterOptions,
 }
 
-impl<'o> Autocompleter<'o> {
+impl Autocompleter {
     /// Creates an autocompleter with the given options.
     ///
     /// # Arguments
@@ -28,15 +28,15 @@ impl<'o> Autocompleter<'o> {
     ///   Instead, they are generated in the Javascript code using Node.js (or Bun).
     ///   To create tables, from the `morcus-net` repo root, run:
     ///   `./morcus.sh build --morceus_tables`
-    /// * `options` - Options for the autocompleter.
+    /// * `default_options` - Default options for the autocompleter.
     pub fn new(
         tables: CruncherTables,
-        options: &'o AutompleterOptions,
-    ) -> Result<Autocompleter<'o>, AutocompleteError> {
+        default_options: AutompleterOptions,
+    ) -> Result<Autocompleter, AutocompleteError> {
         Ok(Autocompleter {
             addenda: Autocompleter::make_addenda(&tables)?,
             tables,
-            options,
+            default_options,
         })
     }
 
@@ -44,8 +44,8 @@ impl<'o> Autocompleter<'o> {
     pub fn completions_for<'t>(
         &'t self,
         prefix: &str,
-    ) -> Result<Vec<AutocompleteResult<'t, 'o>>, AutocompleteError> {
-        self.completions_with_options(prefix, self.options)
+    ) -> Result<Vec<AutocompleteResult<'t, 't>>, AutocompleteError> {
+        self.completions_with_options(prefix, &self.default_options)
     }
 
     /// The main API for fetching completions.

--- a/morceus_rust/src/completions.rs
+++ b/morceus_rust/src/completions.rs
@@ -10,7 +10,7 @@ use crate::{
     completions::{
         autocomplete_result::{IrregResult, StemResult},
         autocompleter::Addenda,
-        find_matches::completions_for_prefix,
+        find_matches::{completions_for_prefix, matches_for_word},
     },
     indices::{CruncherTables, InflectionContext, Lemma},
 };
@@ -68,6 +68,34 @@ impl Autocompleter<'_> {
         options: &'a AutompleterOptions,
     ) -> Result<Vec<AutocompleteResult<'t, 'a>>, AutocompleteError> {
         completions_for_prefix(prefix, self, options)
+    }
+
+    /// The main API for fetching analyses for a full word.
+    ///
+    /// # Arguments
+    /// * `word` - The word to analyze, case-insensitive. This should
+    ///   contain only ascii characters.
+    /// * `limit` - The maximum number of lemmata to return. A single lemma may have multiple
+    ///   inflected forms that match the prefix, but every lemma returned is guaranteed to have
+    ///   at least one matching form.
+    /// * `options` - Display options for formatting the output forms.
+    ///
+    /// # Returns
+    /// A vector of lemmata with analysis results for the given word.
+    pub fn analyses_with_options<'t, 'a>(
+        &'t self,
+        word: &str,
+        options: &'a AutompleterOptions,
+    ) -> Result<Vec<AutocompleteResult<'t, 'a>>, AutocompleteError> {
+        matches_for_word(word, self, options)
+    }
+
+    /// Convenience method to get analyses with default options.
+    pub fn analyses_for<'t>(
+        &'t self,
+        word: &str,
+    ) -> Result<Vec<AutocompleteResult<'t, 't>>, AutocompleteError> {
+        self.analyses_with_options(word, &self.default_options)
     }
 }
 

--- a/morceus_rust/src/completions.rs
+++ b/morceus_rust/src/completions.rs
@@ -14,13 +14,13 @@ use crate::{
 };
 
 /// The main entry point for completions.
-pub struct Autocompleter<'a, 'b> {
-    tables: &'a CruncherTables,
-    addenda: Addenda<'a>,
-    options: &'b AutompleterOptions,
+pub struct Autocompleter<'o> {
+    tables: CruncherTables,
+    addenda: Addenda,
+    options: &'o AutompleterOptions,
 }
 
-impl<'t, 'o> Autocompleter<'t, 'o> {
+impl<'o> Autocompleter<'o> {
     /// Creates an autocompleter with the given options.
     ///
     /// # Arguments
@@ -30,18 +30,18 @@ impl<'t, 'o> Autocompleter<'t, 'o> {
     ///   `./morcus.sh build --morceus_tables`
     /// * `options` - Options for the autocompleter.
     pub fn new(
-        tables: &'t CruncherTables,
+        tables: CruncherTables,
         options: &'o AutompleterOptions,
-    ) -> Result<Autocompleter<'t, 'o>, AutocompleteError> {
+    ) -> Result<Autocompleter<'o>, AutocompleteError> {
         Ok(Autocompleter {
+            addenda: Autocompleter::make_addenda(&tables)?,
             tables,
-            addenda: Autocompleter::make_addenda(tables)?,
             options,
         })
     }
 
     /// Convenience method for fetching completions with default options.
-    pub fn completions_for(
+    pub fn completions_for<'t>(
         &'t self,
         prefix: &str,
     ) -> Result<Vec<AutocompleteResult<'t, 'o>>, AutocompleteError> {
@@ -60,7 +60,7 @@ impl<'t, 'o> Autocompleter<'t, 'o> {
     ///
     /// # Returns
     /// A vector of lemmata with matching completion results.
-    pub fn completions_with_options<'a>(
+    pub fn completions_with_options<'t, 'a>(
         &'t self,
         prefix: &str,
         options: &'a AutompleterOptions,

--- a/morceus_rust/src/completions/autocompleter.rs
+++ b/morceus_rust/src/completions/autocompleter.rs
@@ -11,7 +11,7 @@ pub(super) struct Addenda {
     pub(super) irreg_to_lemma: Vec<u16>,
 }
 
-impl Autocompleter {
+impl Autocompleter<'_> {
     pub(super) fn make_addenda(tables: &CruncherTables) -> Result<Addenda, AutocompleteError> {
         // Reserve the max for "no lemma";
         if tables.raw_lemmata.len() + 1 >= u16::MAX as usize {

--- a/morceus_rust/src/completions/autocompleter.rs
+++ b/morceus_rust/src/completions/autocompleter.rs
@@ -11,7 +11,7 @@ pub(super) struct Addenda {
     pub(super) irreg_to_lemma: Vec<u16>,
 }
 
-impl<'o> Autocompleter<'o> {
+impl Autocompleter {
     pub(super) fn make_addenda(tables: &CruncherTables) -> Result<Addenda, AutocompleteError> {
         // Reserve the max for "no lemma";
         if tables.raw_lemmata.len() + 1 >= u16::MAX as usize {

--- a/morceus_rust/src/completions/find_matches.rs
+++ b/morceus_rust/src/completions/find_matches.rs
@@ -119,7 +119,7 @@ fn filter_lemma_stems<'a>(lemma: &Lemma, ranges: &'a PrefixRanges) -> Vec<(usize
 
 /// Finds the start and end indices of ends for the given stem that start with the given end prefix.
 fn find_ends_for<'a>(
-    completer: &'a Autocompleter<'_>,
+    completer: &'a Autocompleter,
     end_prefix: &str,
     stem: &'a Stem,
 ) -> Result<Option<Vec<&'a InflectionEnding>>, AutocompleteError> {
@@ -164,7 +164,7 @@ fn find_ends_for<'a>(
 fn stem_id_to_result<'a>(
     stem_id: usize,
     unmatched: &str,
-    completer: &'a Autocompleter<'_>,
+    completer: &'a Autocompleter,
 ) -> Result<Option<StemResult<'a>>, AutocompleteError> {
     let stem = &completer.tables.all_stems[stem_id];
     let ends = match find_ends_for(completer, unmatched, stem)? {
@@ -182,7 +182,7 @@ fn stem_id_to_result<'a>(
 fn lemma_id_to_result<'a, 'b>(
     lemma_id: LemmaId,
     ranges: &PrefixRanges,
-    completer: &'a Autocompleter<'_>,
+    completer: &'a Autocompleter,
     display_options: &'b DisplayOptions,
 ) -> Result<AutocompleteResult<'a, 'b>, AutocompleteError> {
     let lemma = completer.lemma_from_id(lemma_id)?;
@@ -244,7 +244,7 @@ fn validated_lemma_result<'a, 'b>(
 
 fn completions_for_prefix_base<'a, 'b>(
     prefix: &str,
-    completer: &'a Autocompleter<'_>,
+    completer: &'a Autocompleter,
     limit: usize,
     options: &'b DisplayOptions,
 ) -> Result<Vec<AutocompleteResult<'a, 'b>>, AutocompleteError> {
@@ -274,7 +274,7 @@ fn completions_for_prefix_base<'a, 'b>(
 
 pub(super) fn completions_for_prefix<'a, 'b>(
     prefix: &str,
-    completer: &'a Autocompleter<'_>,
+    completer: &'a Autocompleter,
     options: &'b AutompleterOptions,
 ) -> Result<Vec<AutocompleteResult<'a, 'b>>, AutocompleteError> {
     let mut variants = vec![prefix.to_string()];

--- a/morceus_rust/src/completions/find_matches.rs
+++ b/morceus_rust/src/completions/find_matches.rs
@@ -119,7 +119,7 @@ fn filter_lemma_stems<'a>(lemma: &Lemma, ranges: &'a PrefixRanges) -> Vec<(usize
 
 /// Finds the start and end indices of ends for the given stem that start with the given end prefix.
 fn find_ends_for<'a>(
-    completer: &Autocompleter<'a, '_>,
+    completer: &'a Autocompleter<'_>,
     end_prefix: &str,
     stem: &'a Stem,
 ) -> Result<Option<Vec<&'a InflectionEnding>>, AutocompleteError> {
@@ -128,7 +128,7 @@ fn find_ends_for<'a>(
         return Ok(None);
     }
     if end_prefix.is_empty() {
-        return Ok(Some(ends.iter().map(|e| e.1).collect()));
+        return Ok(Some(ends.iter().map(|e| &e.1).collect()));
     }
 
     let end_prefix_str = end_prefix.to_string();
@@ -150,7 +150,7 @@ fn find_ends_for<'a>(
     Ok(Some(
         ends[start..start + prefix_end]
             .iter()
-            .map(|e| e.1)
+            .map(|e| &e.1)
             .collect(),
     ))
 }
@@ -164,7 +164,7 @@ fn find_ends_for<'a>(
 fn stem_id_to_result<'a>(
     stem_id: usize,
     unmatched: &str,
-    completer: &Autocompleter<'a, '_>,
+    completer: &'a Autocompleter<'_>,
 ) -> Result<Option<StemResult<'a>>, AutocompleteError> {
     let stem = &completer.tables.all_stems[stem_id];
     let ends = match find_ends_for(completer, unmatched, stem)? {
@@ -182,7 +182,7 @@ fn stem_id_to_result<'a>(
 fn lemma_id_to_result<'a, 'b>(
     lemma_id: LemmaId,
     ranges: &PrefixRanges,
-    completer: &Autocompleter<'a, '_>,
+    completer: &'a Autocompleter<'_>,
     display_options: &'b DisplayOptions,
 ) -> Result<AutocompleteResult<'a, 'b>, AutocompleteError> {
     let lemma = completer.lemma_from_id(lemma_id)?;
@@ -244,11 +244,11 @@ fn validated_lemma_result<'a, 'b>(
 
 fn completions_for_prefix_base<'a, 'b>(
     prefix: &str,
-    completer: &Autocompleter<'a, '_>,
+    completer: &'a Autocompleter<'_>,
     limit: usize,
     options: &'b DisplayOptions,
 ) -> Result<Vec<AutocompleteResult<'a, 'b>>, AutocompleteError> {
-    let ranges = compute_ranges_for(prefix, completer.tables)?;
+    let ranges = compute_ranges_for(prefix, &completer.tables)?;
     let mut seen_ids = HashSet::new();
     let mut results = Vec::new();
 
@@ -274,7 +274,7 @@ fn completions_for_prefix_base<'a, 'b>(
 
 pub(super) fn completions_for_prefix<'a, 'b>(
     prefix: &str,
-    completer: &Autocompleter<'a, '_>,
+    completer: &'a Autocompleter<'_>,
     options: &'b AutompleterOptions,
 ) -> Result<Vec<AutocompleteResult<'a, 'b>>, AutocompleteError> {
     let mut variants = vec![prefix.to_string()];

--- a/morceus_rust/src/completions/find_matches.rs
+++ b/morceus_rust/src/completions/find_matches.rs
@@ -5,7 +5,7 @@ use crate::{
     completions::{
         AutocompleteError, AutocompleteResult, Autocompleter, AutompleterOptions, DisplayOptions,
         StemResult,
-        stem_and_irreg_ranges::{PrefixRanges, compute_ranges_for, find_ranges_of},
+        stem_and_irreg_ranges::{PrefixRanges, compute_ranges_for, find_ranges_of_borrowed},
     },
     indices::{InflectionEnding, Lemma, Stem},
     stem_merging::merge_stem_and_ending,
@@ -118,10 +118,10 @@ fn filter_lemma_stems<'a>(lemma: &Lemma, ranges: &'a PrefixRanges) -> Vec<(usize
 }
 
 #[inline]
-fn key_for_end_entry(entry: &(String, InflectionEnding)) -> String {
+fn key_for_end_entry(entry: &(String, InflectionEnding)) -> &str {
     // TODO: It's unfortunate that we need to clone here, but the range finding
     // function requires owned strings. We can probably optimize this later.
-    entry.0.to_string()
+    &entry.0
 }
 
 /// Finds the start and end indices of ends for the given stem that match with the given end prefix.
@@ -156,10 +156,11 @@ fn find_ends_for<'a>(
         end_prefix.to_string()
     };
 
-    let (start, end) = match find_ranges_of(&end_target, exact_only, ends, key_for_end_entry) {
-        None => return Ok(None),
-        Some(r) => r,
-    };
+    let (start, end) =
+        match find_ranges_of_borrowed(&end_target, exact_only, ends, key_for_end_entry) {
+            None => return Ok(None),
+            Some(r) => r,
+        };
 
     Ok(Some(ends[start..end].iter().map(|e| &e.1).collect()))
 }

--- a/morceus_rust/src/main.rs
+++ b/morceus_rust/src/main.rs
@@ -110,20 +110,21 @@ macro_rules! timed {
 }
 
 #[cfg(feature = "complete")]
-fn handle_complete(args: &[String], tables: CruncherTables) -> Result<(), String> {
+fn handle_complete(args: &[String], tables: &CruncherTables) -> Result<(), String> {
     use morceus::completions::{Autocompleter, AutompleterOptions};
 
     assert_eq!(&args[2], "complete");
     let prefix: &str = &args[3];
 
-    // Set here for illustration on how to create options.
+    // Set here for illustration on how to create options. You can also use ::default().
     let options = AutompleterOptions::builder().relax_i_j(true).build();
+    let tables = std::borrow::Cow::Borrowed(tables);
     let completer = timed!("Created completer", Autocompleter::new(tables, options)?);
     let completions = timed!("Found completions", completer.completions_for(prefix)?);
     print_mem_summary("After finding completions".to_string(), None);
 
     let n = completions.len();
-    println!("Samples completions for '{}' [{}]:", prefix, n);
+    println!("Sample completions for '{}' [{}]:", prefix, n);
     for result in completions {
         println!("- Lemma: {}", result.lemma());
         for word in result.sample_matches() {
@@ -188,7 +189,7 @@ fn main() {
         #[cfg(feature = "crunch")]
         "crunch" => handle_crunch(&args, &tables),
         #[cfg(feature = "complete")]
-        "complete" => handle_complete(&args, tables).unwrap(),
+        "complete" => handle_complete(&args, &tables).unwrap(),
         _ => {
             eprintln!("Unknown command: {}", command);
             process::exit(1);

--- a/morceus_rust/src/main.rs
+++ b/morceus_rust/src/main.rs
@@ -118,7 +118,7 @@ fn handle_complete(args: &[String], tables: CruncherTables) -> Result<(), String
 
     // Set here for illustration on how to create options.
     let options = AutompleterOptions::builder().relax_i_j(true).build();
-    let completer = timed!("Created completer", Autocompleter::new(tables, &options)?);
+    let completer = timed!("Created completer", Autocompleter::new(tables, options)?);
     let completions = timed!("Found completions", completer.completions_for(prefix)?);
     print_mem_summary("After finding completions".to_string(), None);
 

--- a/morceus_rust/src/main.rs
+++ b/morceus_rust/src/main.rs
@@ -110,7 +110,7 @@ macro_rules! timed {
 }
 
 #[cfg(feature = "complete")]
-fn handle_complete(args: &[String], tables: &CruncherTables) -> Result<(), String> {
+fn handle_complete(args: &[String], tables: CruncherTables) -> Result<(), String> {
     use morceus::completions::{Autocompleter, AutompleterOptions};
 
     assert_eq!(&args[2], "complete");
@@ -188,7 +188,7 @@ fn main() {
         #[cfg(feature = "crunch")]
         "crunch" => handle_crunch(&args, &tables),
         #[cfg(feature = "complete")]
-        "complete" => handle_complete(&args, &tables).unwrap(),
+        "complete" => handle_complete(&args, tables).unwrap(),
         _ => {
             eprintln!("Unknown command: {}", command);
             process::exit(1);
@@ -198,4 +198,5 @@ fn main() {
 
 /* Run with:
 cargo run --package morceus --release cli crunch <word>
+cargo run --package morceus --release --no-default-features --features complete cli complete <prefix>
 */


### PR DESCRIPTION
This uses more memory (1 MB) but simplifies structure for callers.